### PR TITLE
Add labels for use in filters and on service pages

### DIFF
--- a/service/data-storage.yml
+++ b/service/data-storage.yml
@@ -5,12 +5,16 @@ Data storage:
     assuranceHint:
     fields:
       - type: boolean
+        filterLabel: Datacentres adhere to EU Code of Conduct for Operations
+        servicePageLabel: Datacentres adhere to EU Code of Conduct for Operations
     validationNotAnswered: "This question requires an answer."
   User-defined data location:
     dependsOnLots: SaaS, PaaS, IaaS
     assuranceApproach:
     fields:
       - type: boolean
+        filterLabel: User-defined data location
+        servicePageLabel: User-defined data location
     validationNotAnswered: "This question requires an answer."
   Datacentre tier:
     hint: Choose one
@@ -19,22 +23,39 @@ Data storage:
     fields:
       - type: radio
         label: TIA-942 Tier 1
+        filterLabel: TIA-942 Tier 1 datacentre
+        servicePageLabel: TIA-942 Tier 1
       - type: radio
         label: TIA-942 Tier 2
+        filterLabel: TIA-942 Tier 2 datacentre
+        servicePageLabel: TIA-942 Tier 2
       - type: radio
         label: TIA-942 Tier 3
+        filterLabel: TIA-942 Tier 3 datacentre
+        servicePageLabel: TIA-942 Tier 3
       - type: radio
         label: TIA-942 Tier 4
+        filterLabel: TIA-942 Tier 4 datacentre
+        servicePageLabel: TIA-942 Tier 4
       - type: radio
         label: Uptime Institute Tier 1
+        filterLabel: Uptime Institute Tier 1 datacentre
+        servicePageLabel: Uptime Institute Tier 1
       - type: radio
         label: Uptime Institute Tier 2
+        filterLabel: Uptime Institute Tier 2 datacentre
+        servicePageLabel: Uptime Institute Tier 2
       - type: radio
         label: Uptime Institute Tier 3
+        filterLabel: Uptime Institute Tier 3 datacentre
+        servicePageLabel: Uptime Institute Tier 3
       - type: radio
         label: Uptime Institute Tier 4
+        filterLabel: Uptime Institute Tier 4 datacentre
+        servicePageLabel: Uptime Institute Tier 4
       - type: radio
         label: None of the above
+        servicePageLabel: Not specified
     validationNotAnswered: "This question requires an answer."
   Backup, disaster recovery and resilience plan in place:
     dependsOnLots: SaaS, PaaS, IaaS
@@ -42,10 +63,14 @@ Data storage:
     hint: "You can provide more detail on your disaster recovery plan in your service definition document."
     fields:
       - type: boolean
+        filterLabel: Backup, disaster recovery and resilience plan in place
+        servicePageLabel: Backup, disaster recovery and resilience plan in place
     validationNotAnswered: "Please answer if plans for backup, disaster recovery and resilience are in place"
   Data extraction/removal plan in place:
     dependsOnLots: SaaS, PaaS, IaaS
     assuranceApproach:
     fields:
       - type: boolean
+        filterLabel: Data extraction/removal plan in place
+        servicePageLabel: Data extraction/removal plan in place
     validationNotAnswered: "This question requires an answer."

--- a/service/data-storage.yml
+++ b/service/data-storage.yml
@@ -1,76 +1,69 @@
 Data storage:
   Datacentres adhere to EU Code of Conduct for Operations:
     dependsOnLots: SaaS, PaaS, IaaS
+    servicePageLabel: Datacentres adhere to EU Code of Conduct for Operations
     assuranceApproach:
     assuranceHint:
     fields:
       - type: boolean
         filterLabel: Datacentres adhere to EU Code of Conduct for Operations
-        servicePageLabel: Datacentres adhere to EU Code of Conduct for Operations
     validationNotAnswered: "This question requires an answer."
   User-defined data location:
     dependsOnLots: SaaS, PaaS, IaaS
+    servicePageLabel: User-defined data location
     assuranceApproach:
     fields:
       - type: boolean
         filterLabel: User-defined data location
-        servicePageLabel: User-defined data location
     validationNotAnswered: "This question requires an answer."
   Datacentre tier:
     hint: Choose one
     dependsOnLots: SaaS, PaaS, IaaS
+    servicePageLabel: Datacentre tier
     assuranceApproach:
     fields:
       - type: radio
         label: TIA-942 Tier 1
         filterLabel: TIA-942 Tier 1 datacentre
-        servicePageLabel: TIA-942 Tier 1
+        displayedResponse: TIA-942 Tier 1
       - type: radio
         label: TIA-942 Tier 2
         filterLabel: TIA-942 Tier 2 datacentre
-        servicePageLabel: TIA-942 Tier 2
       - type: radio
         label: TIA-942 Tier 3
         filterLabel: TIA-942 Tier 3 datacentre
-        servicePageLabel: TIA-942 Tier 3
       - type: radio
         label: TIA-942 Tier 4
         filterLabel: TIA-942 Tier 4 datacentre
-        servicePageLabel: TIA-942 Tier 4
       - type: radio
         label: Uptime Institute Tier 1
         filterLabel: Uptime Institute Tier 1 datacentre
-        servicePageLabel: Uptime Institute Tier 1
       - type: radio
         label: Uptime Institute Tier 2
         filterLabel: Uptime Institute Tier 2 datacentre
-        servicePageLabel: Uptime Institute Tier 2
       - type: radio
         label: Uptime Institute Tier 3
         filterLabel: Uptime Institute Tier 3 datacentre
-        servicePageLabel: Uptime Institute Tier 3
       - type: radio
         label: Uptime Institute Tier 4
         filterLabel: Uptime Institute Tier 4 datacentre
-        servicePageLabel: Uptime Institute Tier 4
       - type: radio
         label: None of the above
-        servicePageLabel: Not specified
     validationNotAnswered: "This question requires an answer."
   Backup, disaster recovery and resilience plan in place:
     dependsOnLots: SaaS, PaaS, IaaS
+    servicePageLabel: Backup, disaster recovery and resilience plan in place
     assuranceApproach:
     hint: "You can provide more detail on your disaster recovery plan in your service definition document."
     fields:
       - type: boolean
         filterLabel: Backup, disaster recovery and resilience plan in place
-        servicePageLabel: Backup, disaster recovery and resilience plan in place
     validationNotAnswered: "Please answer if plans for backup, disaster recovery and resilience are in place"
   Data extraction/removal plan in place:
     dependsOnLots: SaaS, PaaS, IaaS
+    servicePageLabel: Data extraction/removal plan in place
     assuranceApproach:
     fields:
       - type: boolean
         filterLabel: Data extraction/removal plan in place
-        servicePageLabel: Data extraction/removal plan in place
     validationNotAnswered: "This question requires an answer."


### PR DESCRIPTION
_This commit is a *proposal* of content structure. It modifies one page of the content as an example. It is backwards compatible with all current consumers of the content._

We now have the requirement to store this additional information:

#### Service page: An appropriate label for the response the supplier gave to each question in the SSP, eg:
![0450fb42-9038-11e4-9a6d-7a980b400057](https://cloud.githubusercontent.com/assets/355079/5614183/36df1460-94e6-11e4-838d-45a91195fbe4.png)

#### Search results page: A label for each option in a set of filters, eg:
![4c18bbce-94e6-11e4-8b1f-e51d0b32c98b](https://cloud.githubusercontent.com/assets/355079/5614420/e711a6c0-94e8-11e4-88e8-f1f776325036.png)

#### Search results page: Which of the options within the filters are presented to the user, eg we probably don't need to let users filter by 'none of the above' here:
![4c18bbce-94e6-11e4-8b1f-e51d0b32c98b](https://cloud.githubusercontent.com/assets/355079/5614395/954b9f8a-94e8-11e4-80a2-d6b8909c1a47.png)

This proposal adds two new attributes to the content:
- `servicePageLabel` on each question object: The label that will be shown before a supplier's response on a service page
- `filterLabel` to each question's `field` object: The label that will be shown alongside the checkbox when filtering

If `filterLabel` or `servicePageLabel` are omitted then the _intention_ is that the respective filter or response should not be rendered to the page. The implementation of this is left to the application consuming the content.
