### PR TITLE
Hide options for other/none/rest-of-world

### DIFF
--- a/service/networks-and-connectivity.yml
+++ b/service/networks-and-connectivity.yml
@@ -24,5 +24,4 @@ Networks and connectivity:
         filterLabel: Joint Academic Network (JANET)
       - type: checkbox
         label: Other
-        filterLabel: Other
     validationNotAnswered: "This question requires an answer."

--- a/service/security/asset-protection-and-resilience.yml
+++ b/service/security/asset-protection-and-resilience.yml
@@ -20,7 +20,6 @@ Asset protection and resilience:
         filterLabel: "Other countries with data protection treaties"
       - type: checkbox
         label: "Rest of world"
-        filterLabel: "Rest of world"
     validationNotAnswered: "This question requires an answer."
   "Data management location":
     requirements: The geographic location(s) where consumer data is stored, processed or managed from (to country level)
@@ -43,7 +42,6 @@ Asset protection and resilience:
         filterLabel: "Other countries with data protection treaties"
       - type: checkbox
         label: "Rest of world"
-        filterLabel: "Rest of world"
     validationNotAnswered: "This question requires an answer."
   "Legal jurisdiction of service provider":
     requirements: The legal jurisdiction(s) in which the service provider operates
@@ -66,7 +64,6 @@ Asset protection and resilience:
         filterLabel: "Other countries with data protection treaties"
       - type: radio
         label: "Rest of world"
-        filterLabel: "Rest of world"
     validationNotAnswered: "This question requires an answer."
   "Datacentre protection":
     requirements: Consumers should be confident that the physical security measures employed by the provider are sufficient for their intended use of the service.
@@ -102,7 +99,6 @@ Asset protection and resilience:
         filterLabel: "Physical access control"
       - type: radio
         label: "No protection"
-        filterLabel: "No protection"
     validationNotAnswered: "This question requires an answer."
   "Secure data deletion":
     requirements: Consumers should be sufficiently confident that their data is erased when resources are moved or re-provisioned, when they leave the service or when they request it to be erased.
@@ -122,7 +118,6 @@ Asset protection and resilience:
         filterLabel: "Other secure erasure process"
       - type: radio
         label: "Other erasure process"
-        filterLabel: "Other erasure process"
     validationNotAnswered: "This question requires an answer."
   "Storage media disposal":
     requirements: Consumers should be sufficiently confident that storage media which has held consumer data is sanitised or securely destroyed at the end of its life
@@ -151,7 +146,6 @@ Asset protection and resilience:
         filterLabel: "Other secure erasure process"
       - type: radio
         label: "Other destruction/erasure process"
-        filterLabel: "Other destruction/erasure process"
     validationNotAnswered: "This question requires an answer."
   "Secure equipment disposal":
     requirements: Consumers should be sufficiently confident that all equipment potentially containing consumer data, credentials, or configuration information for the service is identified at the end of its life (or prior to being recycled).

--- a/service/security/audit-information-provision-to-consumers.yml
+++ b/service/security/audit-information-provision-to-consumers.yml
@@ -8,7 +8,6 @@ Audit information provision to consumers:
     fields:
       - type: radio
         label: "None"
-        filterLabel: "None"
       - type: radio
         label: "Data made available"
         filterLabel: "Data made available"

--- a/service/security/data-in-transit-protection.yml
+++ b/service/security/data-in-transit-protection.yml
@@ -24,7 +24,6 @@ Data-in-transit protection:
         filterLabel: "VPN using legacy SSL or TLS"
       - type: radio
         label: "No encryption"
-        filterLabel: "No encryption"
     validationNotAnswered: "This question requires an answer."
   "Data protection within service":
     requirements: Data in transit is protected internally within the service
@@ -50,7 +49,6 @@ Data-in-transit protection:
         filterLabel: "Other network protection"
       - type: radio
         label: "No encryption"
-        filterLabel: "No encryption"
     validationNotAnswered: "This question requires an answer."
   "Data protection between services":
     requirements: Data in transit is protected between the service and other services (eg where APIs are exposed)
@@ -76,5 +74,4 @@ Data-in-transit protection:
         filterLabel: "VPN using legacy SSL or TLS"
       - type: radio
         label: "No encryption"
-        filterLabel: "No encryption"
     validationNotAnswered: "This question requires an answer."

--- a/service/security/identity-and-authentication.yml
+++ b/service/security/identity-and-authentication.yml
@@ -26,5 +26,4 @@ Identity and authentication:
         filterLabel: "Username and strong password/passphrase enforcement"
       - type: checkbox
         label: "Other mechanism"
-        filterLabel: "Other mechanism"
     validationNotAnswered: "This question requires an answer."

--- a/service/security/separation-between-consumers.yml
+++ b/service/security/separation-between-consumers.yml
@@ -37,7 +37,6 @@ Separation between consumers:
         filterLabel: "A specific consumer group, eg Police, Defence or Health"
       - type: radio
         label: "Anyone - public"
-        filterLabel: "Anyone - public"
     validationNotAnswered: "This question requires an answer."
   "Services separation":
     requirements: Consumers should have confidence that the service provides sufficient separation of their data and service from other consumers of the service.

--- a/service/terms-and-conditions.yml
+++ b/service/terms-and-conditions.yml
@@ -22,7 +22,6 @@ Terms and conditions:
         filterLabel: "Year"
       - type: radio
         label: "Other"
-        filterLabel: "Other"
     validationNotAnswered: "This question requires an answer."
   Please upload your terms and conditions document:
     mockAnswer: Umbraco Terms_Conditions 102014.odf


### PR DESCRIPTION
It doesn't seem desirable or advisable for buyers to search for services which don't match any of the clearly-defined options. For example:

**Probably useful** to show only services that support *TLS 1.2 or later*

**Probably not useful** to show only that have *no encryption*

This commit hides the second kind of option by removing their `filterLabel` attribute.

Requires merging of https://github.com/alphagov/digital-marketplace-prototype/pull/7 for the effect to be visible.