### PR TITLE
Add a key to identify each question

### DIFF
--- a/service/access.yml
+++ b/service/access.yml
@@ -1,5 +1,6 @@
 Access:
   Supported web browsers:
+    key: supportedBrowsers
     dependsOnLots: SaaS, PaaS, IaaS
     hint: "Choose all that apply."
     fields:
@@ -32,12 +33,14 @@ Access:
         filterLabel: Opera
     validationNotAnswered: "This question requires an answer."
   Offline working and syncing supported:
+    key: offlineWorking
     dependsOnLots: SaaS, PaaS, IaaS
     fields:
       - type: boolean
         filterLabel: Offline working and syncing supported
     validationNotAnswered: "This question requires an answer."
   Supported devices:
+    key: supportedDevices
     dependsOnLots: SaaS, PaaS, IaaS
     hint: "Choose all that apply."
     fields:

--- a/service/analytics.yml
+++ b/service/analytics.yml
@@ -1,5 +1,6 @@
 Analytics:
   Real-time management information available:
+    key: analyticsAvailable
     dependsOnLots: SaaS, PaaS, IaaS
     fields:
       - type: boolean

--- a/service/api-access.yml
+++ b/service/api-access.yml
@@ -1,11 +1,13 @@
 API access:
   API access available and supported:
+    key: apiAccess
     dependsOnLots: SaaS, PaaS, IaaS
     fields:
       - type: boolean
         filterLabel: API access available and supported
     validationNotAnswered: "This question requires an answer."
   API type:
+    key: apiType
     dependsOnLots: SaaS, PaaS, IaaS
     hint: "Examples of API include RESTful and SOAP."
     fields:

--- a/service/certifications.yml
+++ b/service/certifications.yml
@@ -1,5 +1,6 @@
 Certifications:
   Vendor certification(s):
+    key: vendorCertifications
     dependsOnLots: SaaS, PaaS, IaaS, SCS
     hint: "Examples of certifications include VMware Certified Professional and Oracle Gold Partner. (Optional.)"
     listItemName: "certification example"

--- a/service/cloud-features.yml
+++ b/service/cloud-features.yml
@@ -1,17 +1,20 @@
 Cloud features:
   Elastic cloud approach supported:
+    key: elasticCloud
     dependsOnLots: SaaS, PaaS, IaaS
     fields:
       - type: boolean
         filterLabel: Elastic cloud approach supported
     validationNotAnswered: "This question requires an answer."
   Guaranteed resources defined:
+    key: guaranteedResources
     dependsOnLots: SaaS, PaaS, IaaS
     fields:
       - type: boolean
         filterLabel: Guaranteed resources defined
     validationNotAnswered: "This question requires an answer."
   Persistent storage supported:
+    key: persistantStorage
     dependsOnLots: SaaS, PaaS, IaaS
     fields:
       - type: boolean

--- a/service/code-libraries.yml
+++ b/service/code-libraries.yml
@@ -1,5 +1,6 @@
 Code libraries:
   Languages your code libraries are written in:
+    key: codeLibraryLanguages
     dependsOnLots: SaaS
     hint: "Examples of code libraries include AWS Ruby SDK and Stripe-Java. Examples of languages include PHP and Python. (Maximum 10 languages.) (Optional.) "
     listItemName: "code libraries example"

--- a/service/data-storage.yml
+++ b/service/data-storage.yml
@@ -1,5 +1,6 @@
 Data storage:
   Datacentres adhere to EU Code of Conduct for Operations:
+    key: datacentresEUCode
     dependsOnLots: SaaS, PaaS, IaaS
     servicePageLabel: Datacentres adhere to EU Code of Conduct for Operations
     assuranceApproach:
@@ -9,6 +10,7 @@ Data storage:
         filterLabel: Datacentres adhere to EU Code of Conduct for Operations
     validationNotAnswered: "This question requires an answer."
   User-defined data location:
+    key: datacentresSpecifyLocation
     dependsOnLots: SaaS, PaaS, IaaS
     servicePageLabel: User-defined data location
     assuranceApproach:
@@ -17,6 +19,7 @@ Data storage:
         filterLabel: User-defined data location
     validationNotAnswered: "This question requires an answer."
   Datacentre tier:
+    key: datacentreTier
     hint: Choose one
     dependsOnLots: SaaS, PaaS, IaaS
     servicePageLabel: Datacentre tier
@@ -51,6 +54,7 @@ Data storage:
         label: None of the above
     validationNotAnswered: "This question requires an answer."
   Backup, disaster recovery and resilience plan in place:
+    key: dataBackupRecovery
     dependsOnLots: SaaS, PaaS, IaaS
     servicePageLabel: Backup, disaster recovery and resilience plan in place
     assuranceApproach:
@@ -60,6 +64,7 @@ Data storage:
         filterLabel: Backup, disaster recovery and resilience plan in place
     validationNotAnswered: "Please answer if plans for backup, disaster recovery and resilience are in place"
   Data extraction/removal plan in place:
+    key: dataExtractionRemoval
     dependsOnLots: SaaS, PaaS, IaaS
     servicePageLabel: Data extraction/removal plan in place
     assuranceApproach:

--- a/service/features-and-benefits.yml
+++ b/service/features-and-benefits.yml
@@ -1,5 +1,6 @@
 Features and benefits:
   Service features:
+    key: serviceFeatures
     hint: "Include the technical features of your product, eg graphical workflow, remote access. (Maximum 10 words per feature. Maximum 10 features.)"
     mockAnswer: "Graphical workflow, Remote access, Revision control"
     dependsOnLots: SaaS, PaaS, IaaS, SCS
@@ -9,6 +10,7 @@ Features and benefits:
         addthing: Add another feature
     validationNotAnswered: "This question requires an answer."
   Service benefits:
+    key: serviceBenefits
     hint: "Include benefits that show how your service helps users improve their business. Use active phrases, eg publish content from multiple devices, quickly manage content on the move.  (Maximum 10 words per benefit. Maximum 10 benefits.)"
     mockAnswer: "Publish content, Quickly manage content on the move"
     dependsOnLots: SaaS, PaaS, IaaS, SCS

--- a/service/identity-standards.yml
+++ b/service/identity-standards.yml
@@ -1,5 +1,6 @@
 Identity standards:
   Identity standards your service uses:
+    key: identityStandards
     dependsOnLots: SaaS
     hint: "Examples of identity standards include OAuth and SAML. (Optional.)"
     listItemName: "identity standards example"

--- a/service/networks-and-connectivity.yml
+++ b/service/networks-and-connectivity.yml
@@ -1,5 +1,6 @@
 Networks and connectivity:
   Networks the service is directly connected to:
+    key: networksConnected
     dependsOnLots: SaaS, PaaS, IaaS
     mockAnswer: Internet
     hint: "Choose all that apply."

--- a/service/onboarding-and-offboarding.yml
+++ b/service/onboarding-and-offboarding.yml
@@ -1,11 +1,13 @@
 Onboarding and offboarding:
   Service onboarding process included:
+    key: serviceOnboarding
     dependsOnLots: SaaS, PaaS, IaaS
     fields:
       - type: boolean
         filterLabel: Service onboarding process included
     validationNotAnswered: "This question requires an answer."
   Service offboarding process included:
+    key: serviceOffboarding
     dependsOnLots: SaaS, PaaS, IaaS
     fields:
       - type: boolean

--- a/service/open-source.yml
+++ b/service/open-source.yml
@@ -1,5 +1,6 @@
 Open source:
   Open-source software used and supported:
+    key: openSource
     dependsOnLots: SaaS, PaaS, IaaS
     fields:
       - type: boolean

--- a/service/open-standards.yml
+++ b/service/open-standards.yml
@@ -1,5 +1,6 @@
 Open standards:
   Open standards supported and documented:
+    key: openStandardsSupported
     dependsOnLots: SaaS, PaaS, IaaS
     hint: "Take a look at the GOV.UK Open Standards principles for more information on open standards."
     fields:

--- a/service/pricing.yml
+++ b/service/pricing.yml
@@ -1,5 +1,6 @@
 Pricing:
   Service price:
+    key: servicePrice
     hint: "This is an indicative price. Users will be able to refer to your pricing document for more information."
     dependsOnLots: SaaS, PaaS, IaaS, SCS
     validationNoMinPriceSpecified: "Minimum price requires an answer."
@@ -9,12 +10,14 @@ Pricing:
     fields:
       - type: pricing
   VAT included:
+    key: vatIncluded
     dependsOnLots: SaaS, PaaS, IaaS, SCS
     fields:
       - type: boolean
         filterLabel: VAT included
     validationNotAnswered: "This question requires an answer."
   Education pricing:
+    key: educationPricing
     dependsOnLots: SaaS, PaaS, IaaS, SCS
     hint: "Do you offer special pricing for educational organisations?"
     fields:
@@ -22,18 +25,21 @@ Pricing:
         filterLabel: Education pricing
     validationNotAnswered: "This question requires an answer."
   Trial option:
+    key: trialOption
     dependsOnLots: SaaS, PaaS, IaaS
     fields:
       - type: boolean
         filterLabel: Trial option
     validationNotAnswered: "This question requires an answer."
   Free option:
+    key: freeOption
     dependsOnLots: SaaS, PaaS, IaaS
     fields:
       - type: boolean
         filterLabel: Free option
     validationNotAnswered: "This question requires an answer."
   Pricing document:
+    key: pricingDocument
     dependsOnLots: SaaS, PaaS, IaaS, SCS
     mockAnswer: Pricing Document Umbraco 102014.odf
     hint: "Please upload your pricing document. This document will not be indexed by search on the Digital Marketplace. Use an Open Document Format (ODF) or PDF/A (eg .pdf, .odt). (Maximum file size 5MB.)"
@@ -44,6 +50,7 @@ Pricing:
     validationWrongFormat: "Your document is not in an open format. Please save as an Open Document Format (ODF) or PDF/A (eg .pdf, .odt)."
     validationTooLarge: "Your document exceeds the 5MB limit. Please reduce file size."
   Skills Framework for the Information Age (SFIA) rate card:
+    key: sfiaRateCard
     dependsOnLots: SaaS, PaaS, IaaS, SCS
     mockAnswer: Rate Card Umbraco 102014.odf
     hint: "Please upload your SFIA rate card if you have one. This document will not be indexed by search on the Digital Marketplace. Use an Open Document Format (ODF) or PDF/A (eg .pdf, .odt). (Maximum file size 5MB.)"

--- a/service/provisioning.yml
+++ b/service/provisioning.yml
@@ -1,17 +1,20 @@
 Provisioning:
   Self-service provisioning supported:
+    key: selfServiceProvisioning
     dependsOnLots: SaaS, PaaS, IaaS
     fields:
       - type: boolean
         filterLabel: Self-service provisioning supported
     validationNotAnswered: "This question requires an answer."
   Service provisioning time:
+    key: provisioningTime
     dependsOnLots: SaaS, PaaS, IaaS
     hint: "How long does it take to get your service up and running? For example 1 to 5 hours, 2 to 3 days."
     fields:
       - type: text
     validationNotAnswered: "This question requires an answer."
   Service deprovisioning time:
+    key: deprovisioningTime
     dependsOnLots: SaaS, PaaS, IaaS
     hint: ""
     fields:

--- a/service/security/asset-protection-and-resilience.yml
+++ b/service/security/asset-protection-and-resilience.yml
@@ -1,5 +1,6 @@
 Asset protection and resilience:
   "Datacentre location":
+    key: datacentreLocations
     requirements: The geographic location(s) where consumer data is stored, processed or managed from (to country level)
     filters: The geographic location(s) where consumer data is stored, processed or managed from (to country level)
     hint: "Where are the service provider's datacentres located? Choose all that apply."
@@ -22,6 +23,7 @@ Asset protection and resilience:
         label: "Rest of world"
     validationNotAnswered: "This question requires an answer."
   "Data management location":
+    key: dataManagementLocations
     requirements: The geographic location(s) where consumer data is stored, processed or managed from (to country level)
     filters: The geographic location(s) where consumer data is stored, processed or managed from (to country level)
     hint: "Where are the services managed from? Choose all that apply."
@@ -44,6 +46,7 @@ Asset protection and resilience:
         label: "Rest of world"
     validationNotAnswered: "This question requires an answer."
   "Legal jurisdiction of service provider":
+    key: legalJurisdiction
     requirements: The legal jurisdiction(s) in which the service provider operates
     filters: The legal jurisdiction(s) in which the service provider operates
     hint: "Choose 1"
@@ -66,6 +69,7 @@ Asset protection and resilience:
         label: "Rest of world"
     validationNotAnswered: "This question requires an answer."
   "Datacentre protection":
+    key: datacentreProtectionDisclosure
     requirements: Consumers should be confident that the physical security measures employed by the provider are sufficient for their intended use of the service.
     filters: Consumers should be confident that the physical security measures employed by the provider are sufficient for their intended use of the service.
     hint: "Do you tell your consumers what physical security your datacentres have?"
@@ -76,6 +80,7 @@ Asset protection and resilience:
         filterLabel: Datacentre protection
     validationNotAnswered: "This question requires an answer."
   "Data-at-rest protection":
+    key: dataAtRestProtection
     requirements: Consumers should have sufficient confidence that storage media containing their data is protected from unauthorised access.
     filters: Consumers should have sufficient confidence that storage media containing their data is protected from unauthorised access.
     hint: "How is storage media containing consumer data protected from unauthorised physical access? Choose 1."
@@ -101,6 +106,7 @@ Asset protection and resilience:
         label: "No protection"
     validationNotAnswered: "This question requires an answer."
   "Secure data deletion":
+    key: dataSecureDeletion
     requirements: Consumers should be sufficiently confident that their data is erased when resources are moved or re-provisioned, when they leave the service or when they request it to be erased.
     filters: Consumers should be sufficiently confident that their data is erased when resources are moved or re-provisioned, when they leave the service or when they request it to be erased.
     hint: "How do you erase consumer data when resources are moved or re-provisioned, or when the consumer leaves the service, or when they request it to be erased? Choose 1."
@@ -120,6 +126,7 @@ Asset protection and resilience:
         label: "Other erasure process"
     validationNotAnswered: "This question requires an answer."
   "Storage media disposal":
+    key: dataStorageMediaDisposal
     requirements: Consumers should be sufficiently confident that storage media which has held consumer data is sanitised or securely destroyed at the end of its life
     filters: Consumers should be sufficiently confident that storage media which has held consumer data is sanitised or securely destroyed at the end of its life
     hint: "How is storage media containing consumer data sanitised or securely destroyed at the end of its usable lifetime? Choose 1."
@@ -148,6 +155,7 @@ Asset protection and resilience:
         label: "Other destruction/erasure process"
     validationNotAnswered: "This question requires an answer."
   "Secure equipment disposal":
+    key: dataSecureEquipmentDisposal
     requirements: Consumers should be sufficiently confident that all equipment potentially containing consumer data, credentials, or configuration information for the service is identified at the end of its life (or prior to being recycled).
     filters: Consumers should be sufficiently confident that all equipment potentially containing consumer data, credentials, or configuration information for the service is identified at the end of its life (or prior to being recycled).
     hint: "Is all equipment potentially containing consumer data, credentials or configuration information identified at the end of its life or prior to being recycled? Choose 1."
@@ -158,6 +166,7 @@ Asset protection and resilience:
         filterLabel: Secure equipment disposal
     validationNotAnswered: "This question requires an answer."
   "Redundant equipment accounts revoked":
+    key: dataRedundantEquipmentAccountsRevoked
     requirements: Consumers should be sufficiently confident that accounts or credentials specific to redundant equipment are revoked to reduce their value to an attacker.
     filters: Consumers should be sufficiently confident that accounts or credentials specific to redundant equipment are revoked to reduce their value to an attacker.
     hint: "Are accounts or credentials specific to redundant equipment revoked to reduce their value to an attacker?"
@@ -168,6 +177,7 @@ Asset protection and resilience:
         filterLabel: Redundant equipment accounts revoked
     validationNotAnswered: "This question requires an answer."
   "Service availability":
+    key: serviceAvailabilityPercentage
     requirements: Consumers should be sufficiently confident that the availability commitments of the service, including their ability to recover from outages, meets their business needs.
     filters: Consumers should be sufficiently confident that the availability commitments of the service, including their ability to recover from outages, meets their business needs.
     hint: "What is the availability of the service? eg 99.99"

--- a/service/security/audit-information-provision-to-consumers.yml
+++ b/service/security/audit-information-provision-to-consumers.yml
@@ -1,5 +1,6 @@
 Audit information provision to consumers:
   "Audit information provided":
+    key: auditInformationProvided
     requirements: Consumers are aware of the audit information that will be provided to them, how and when it will be made available to them, the format of the data, and the retention period associated with it.
     filters: Consumers are aware of the audit information that will be provided to them, how and when it will be made available to them, the format of the data, and the retention period associated with it.
     hint: "Do you provide audit information to consumers? Choose 1."

--- a/service/security/authentication-of-consumers-to-management-interfaces-and-within-support-channels.yml
+++ b/service/security/authentication-of-consumers-to-management-interfaces-and-within-support-channels.yml
@@ -1,5 +1,6 @@
 Authentication of consumers:
   "User authentication and access management":
+    key: userAuthenticateManagement
     requirements: The consumer has sufficient confidence that only authorised individuals from the consumer organisation are able to authenticate to and access management interfaces for the service (Principle 10 should be used assess the risks of different approaches to meet this objective).
     filters: The consumer has sufficient confidence that only authorised individuals from the consumer organisation are able to authenticate to and access management interfaces for the service (Principle 10 should be used assess the risks of different approaches to meet this objective).
     hint: "Can only authorised individuals from the consumer organisation access management interfaces for the service?"
@@ -10,6 +11,7 @@ Authentication of consumers:
         filterLabel: User authentication and access management
     validationNotAnswered: "This question requires an answer."
   "User access control through support channels":
+    key: userAuthenticateSupport
     requirements: The consumer has sufficient confidence that only authorised individuals from the consumer organisation are able to perform actions affecting the consumer’s service through support channels.
     filters: The consumer has sufficient confidence that only authorised individuals from the consumer organisation are able to perform actions affecting the consumer’s service through support channels.
     hint: "Can only authorised individuals from the consumer organisation perform actions affecting the consumer’s service through your support channels?"

--- a/service/security/configuration-and-change-management.yml
+++ b/service/security/configuration-and-change-management.yml
@@ -1,5 +1,6 @@
 Configuration and change management:
   "Configuration and change management tracking":
+    key: configurationTracking
     requirements: Consumers should have confidence that the status, location and configuration of service components (including hardware and software components) are tracked throughout their lifetime within the service.
     filters: Consumers should have confidence that the status, location and configuration of service components (including hardware and software components) are tracked throughout their lifetime within the service.
     hint: "Do you track the status, location and configuration of service components throughout their lifetime?"
@@ -10,6 +11,7 @@ Configuration and change management:
         filterLabel: Configuration and change management tracking
     validationNotAnswered: "This question requires an answer."
   "Change impact assessment":
+    key: changeImpactAssessment
     requirements: Consumers should have confidence that changes to the service are assessed for potential security impact. Changes are managed and tracked through to completion.
     filters: Consumers should have confidence that changes to the service are assessed for potential security impact. Changes are managed and tracked through to completion.
     hint: "Are changes to the service assessed for potential security impact, and are changes managed and tracked through to completion?"

--- a/service/security/data-in-transit-protection.yml
+++ b/service/security/data-in-transit-protection.yml
@@ -1,5 +1,6 @@
 Data-in-transit protection:
   "Data protection between user device and service":
+    key: dataProtectionBetweenUserAndService
     requirements: Data in transit is protected between the user’s devices and the service
     filters: Data in transit is protected between the user’s devices and the service
     hint: "Choose 1"
@@ -26,6 +27,7 @@ Data-in-transit protection:
         label: "No encryption"
     validationNotAnswered: "This question requires an answer."
   "Data protection within service":
+    key: dataProtctionWithinService
     requirements: Data in transit is protected internally within the service
     filters: Data in transit is protected internally within the service
     hint: "Choose 1"
@@ -51,6 +53,7 @@ Data-in-transit protection:
         label: "No encryption"
     validationNotAnswered: "This question requires an answer."
   "Data protection between services":
+    key: dataProtectionBetweenServices
     requirements: Data in transit is protected between the service and other services (eg where APIs are exposed)
     filters: Data in transit is protected between the service and other services (eg where APIs are exposed)
     hint: "Choose 1"

--- a/service/security/external-interface-protection.yml
+++ b/service/security/external-interface-protection.yml
@@ -1,5 +1,6 @@
 External interface protection:
   "Onboarding guidance provided":
+    key: onboardingGuidance
     requirements: The consumer understands how to safely connect to the service whilst minimising risk to the consumer’s systems.
     filters: The consumer understands how to safely connect to the service whilst minimising risk to the consumer’s systems.
     hint: "Do you provide onboarding guidance covering secure connection to the service?"
@@ -10,6 +11,7 @@ External interface protection:
         filterLabel: Onboarding guidance provided
     validationNotAnswered: "This question requires an answer."
   "Interconnection method provided":
+    key: interconnectionMethods
     requirements: The consumer understands what physical and logical interfaces their information is available from.
     filters: The consumer understands what physical and logical interfaces their information is available from.
     hint: "What method of interconnection to the service do you provide? Choose all that apply."

--- a/service/security/governance.yml
+++ b/service/security/governance.yml
@@ -1,5 +1,6 @@
 Governance:
   "Governance framework":
+    key: governanceFramework
     requirements: The consumer should have sufficient confidence that the governance framework and processes in place for the service are appropriate for their intended use of it.
     filters: The consumer should have sufficient confidence that the governance framework and processes in place for the service are appropriate for their intended use of it.
     hint: "Do you have a governance framework and process in place for the service, eg ISO277001:2013?"

--- a/service/security/identity-and-authentication.yml
+++ b/service/security/identity-and-authentication.yml
@@ -1,5 +1,6 @@
 Identity and authentication:
   "Identity and authentication controls":
+    key: identityAuthenticationControls
     requirements: Consumers should have sufficient confidence that identity and authentication controls ensure users are authorised to access specific interfaces.
     filters: Consumers should have sufficient confidence that identity and authentication controls ensure users are authorised to access specific interfaces.
     hint: "How do your identity and authentication controls ensure that users are authorised to access specific interfaces? Choose all that apply."

--- a/service/security/incident-management.yml
+++ b/service/security/incident-management.yml
@@ -1,5 +1,6 @@
 Incident management:
   "Incident management processes":
+    key: incidentManagementProcess
     requirements: Consumers should have confidence that incident management processes are in place for the service and are enacted in response to security incidents.
     filters: Consumers should have confidence that incident management processes are in place for the service and are enacted in response to security incidents.
     hint: "Do you have incident management processes in place and are they enacted in response to security incidents?"
@@ -10,6 +11,7 @@ Incident management:
         filterLabel: Incident management processes
     validationNotAnswered: "This question requires an answer."
   "Consumer reporting of security incidents":
+    key: incidentManagementReporting
     requirements: Consumers should have confidence that pre-defined processes are in place for responding to common types of incident and attack.
     filters: Consumers should have confidence that pre-defined processes are in place for responding to common types of incident and attack.
     hint: "Do you have a defined process for reporting security incidents experienced by consumers and external entities?"
@@ -20,6 +22,7 @@ Incident management:
         filterLabel: Consumer reporting of security incidents
     validationNotAnswered: "This question requires an answer."
   "Security incident definition published":
+    key: incidentDefinitionPublished
     requirements: Consumers should have confidence that a defined process and contact route exists for reporting of security incidents by consumers and external entities.
     filters: Consumers should have confidence that a defined process and contact route exists for reporting of security incidents by consumers and external entities.
     dependsOnLots: SaaS, PaaS, IaaS

--- a/service/security/personnel-security.yml
+++ b/service/security/personnel-security.yml
@@ -1,5 +1,6 @@
 Personnel security:
   "Personnel security checks":
+    key: personnelSecurityChecks
     requirements: Consumers should be content with the level of security screening conducted on service provider staff with access to their information or with ability to affect their service.
     filters: Consumers should be content with the level of security screening conducted on service provider staff with access to their information or with ability to affect their service.
     hint: "What kind of personnel security do you apply to staff who have access to the service? Choose all that apply."

--- a/service/security/protective-monitoring.yml
+++ b/service/security/protective-monitoring.yml
@@ -1,5 +1,6 @@
 Event monitoring:
   "Event monitoring":
+    key: eventMonitoring
     requirements: Consumers should have confidence that events generated in service components required to support effective identification of suspicious activity are collected and fed into an analysis system.
     filters: Consumers should have confidence that events generated in service components required to support effective identification of suspicious activity are collected and fed into an analysis system.
     hint: "Do you conduct event monitoring and analysis to identify suspicious activity?"

--- a/service/security/secure-development.yml
+++ b/service/security/secure-development.yml
@@ -1,5 +1,6 @@
 Secure development:
   "Secure development":
+    key: secureDevelopment
     requirements: Consumers should be sufficiently confident that new and evolving threats are reviewed and the service improved in line with them.
     filters: Consumers should be sufficiently confident that new and evolving threats are reviewed and the service improved in line with them.
     hint: "Are new and evolving threats reviewed and your services improved accordingly?"
@@ -10,6 +11,7 @@ Secure development:
         filterLabel: Secure development
     validationNotAnswered: "This question requires an answer."
   "Secure design, coding, testing and deployment":
+    key: secureDesign
     requirements: Consumers should be sufficiently confident that development is carried out in line with industry good practice regarding secure design, coding, testing and deployment.
     filters: Consumers should be sufficiently confident that development is carried out in line with industry good practice regarding secure design, coding, testing and deployment.
     hint: "Is development carried out in line with industry good practice regarding secure design, coding, testing and deployment?"
@@ -20,6 +22,7 @@ Secure development:
         filterLabel: Secure design, coding, testing and deployment
     validationNotAnswered: "This question requires an answer."
   "Software configuration management":
+    key: secureConfigurationManagement
     requirements: Consumers should be sufficiently confident that configuration management processes are in place to ensure the integrity of the solution through development, testing and deployment.
     filters: Consumers should be sufficiently confident that configuration management processes are in place to ensure the integrity of the solution through development, testing and deployment.
     hint: "Do you have configuration management in place to ensure the integrity of the service through development, testing and deployment?"

--- a/service/security/secure-service-administration.yml
+++ b/service/security/secure-service-administration.yml
@@ -1,5 +1,6 @@
 Secure service administration:
   "Service management model":
+    key: serviceManagementModel
     requirements: Consumers have sufficient confidence that the technical approach the service provider uses to manage the service does not put their data or service at risk.
     filters: Consumers have sufficient confidence that the technical approach the service provider uses to manage the service does not put their data or service at risk.
     hint: "Which technical approach do you use for your service management? Choose 1."

--- a/service/security/secure-use-of-the-service-by-the-customer.yml
+++ b/service/security/secure-use-of-the-service-by-the-customer.yml
@@ -1,5 +1,6 @@
 Secure use of the service by the customer:
   "Device access method":
+    key: deviceAccessMethod
     requirements: The consumer understands any service configuration options available to them and the security implications of choices they make.
     filters: The consumer understands any service configuration options available to them and the security implications of choices they make.
     hint: "Which end device is the cloud service accessible from?"
@@ -17,6 +18,7 @@ Secure use of the service by the customer:
         filterLabel: "Unknown devices"
     validationNotAnswered: "This question requires an answer."
   "Service configuration guidance":
+    key: serviceConfigurationGuidance
     requirements: The consumer understands the security requirements on their processes, uses, and infrastructure related to the use of the service.
     filters: The consumer understands the security requirements on their processes, uses, and infrastructure related to the use of the service.
     hint: "Do you provide guidance on service configuration options and the relative impacts on security?"
@@ -27,6 +29,7 @@ Secure use of the service by the customer:
         filterLabel: Service configuration guidance
     validationNotAnswered: "This question requires an answer."
   "Training":
+    key: trainingProvided
     requirements: The consumer can educate those administrating and using the service in how to use it safely and securely.
     filters: The consumer can educate those administrating and using the service in how to use it safely and securely.
     hint: "Do you provide user or administrator training on the use of the service and its security?"

--- a/service/security/separation-and-access-control-within-management-interfaces.yml
+++ b/service/security/separation-and-access-control-within-management-interfaces.yml
@@ -1,5 +1,6 @@
 Separation and access control within management interfaces:
   "User access control within management interfaces":
+    key: userAccessControlManagement
     requirements: The consumer has sufficient confidence that other consumers cannot access, modify or otherwise affect their service management.
     filters: The consumer has sufficient confidence that other consumers cannot access, modify or otherwise affect their service management.
     hint: "Can consumers manage only their own service, and not access, modify or otherwise affect the service of other consumers via management tools and interfaces?"
@@ -10,6 +11,7 @@ Separation and access control within management interfaces:
         filterLabel: User access control within management interfaces
     validationNotAnswered: "This question requires an answer."
   "Administrator permissions":
+    key: restrictAdministratorPermissions
     requirements: The consumer can manage the risks of their own privileged access, e.g. through ‘principle of least privilege’, providing the ability to constrain permissions given to consumer administrators.
     filters: The consumer can manage the risks of their own privileged access, e.g. through ‘principle of least privilege’, providing the ability to constrain permissions given to consumer administrators.
     hint: "Can consumers restrict permissions given to their administrators?"
@@ -20,6 +22,7 @@ Separation and access control within management interfaces:
         filterLabel: Administrator permissions
     validationNotAnswered: "This question requires an answer."
   "Management interface protection":
+    key: managementInterfaceProtection
     requirements: The consumer understands how management interfaces are protected (see Principle 11) and what functionality is available via those interfaces.
     filters: The consumer understands how management interfaces are protected (see Principle 11) and what functionality is available via those interfaces.
     hint: "Do you tell consumers what functionality and protection is available for management interfaces?"

--- a/service/security/separation-between-consumers.yml
+++ b/service/security/separation-between-consumers.yml
@@ -1,5 +1,6 @@
 Separation between consumers:
   "Cloud deployment model":
+    key: cloudDeploymentModel
     requirements: Service providers must state whether the service is a public, private or community cloud service.
     filters: Service providers must state whether the service is a public, private or community cloud service.
     hint: "Is the service a public, private, community or hybrid cloud service?"
@@ -20,6 +21,7 @@ Separation between consumers:
         filterLabel: "Hybrid cloud"
     validationNotAnswered: "This question requires an answer."
   "Type of consumer":
+    key: otherConsumers
     requirements: Consumers should understand the types of consumer they share the service or platform with.
     filters: Consumers should understand the types of consumer they share the service or platform with.
     hint: "What types of other consumer do you share the service or platform with?"
@@ -39,6 +41,7 @@ Separation between consumers:
         label: "Anyone - public"
     validationNotAnswered: "This question requires an answer."
   "Services separation":
+    key: servicesSeparation
     requirements: Consumers should have confidence that the service provides sufficient separation of their data and service from other consumers of the service.
     filters: Consumers should have confidence that the service provides sufficient separation of their data and service from other consumers of the service.
     hint: "Do you securely separate consumer data and services from other consumers of the service?"
@@ -49,6 +52,7 @@ Separation between consumers:
         filterLabel: Services separation
     validationNotAnswered: "This question requires an answer."
   "Services management separation":
+    key: servicesManagementSepartion
     requirements: Consumers should have confidence that their management of the service is kept separate from other consumers (covered separately as part of Principle 9).
     filters: Consumers should have confidence that their management of the service is kept separate from other consumers (covered separately as part of Principle 9).
     hint: "Is your management of a consumer’s service kept separate from other consumers?"

--- a/service/security/supply-chain-security.yml
+++ b/service/security/supply-chain-security.yml
@@ -1,5 +1,6 @@
 Supply-chain security:
   "Visibility of data shared with third-party suppliers":
+    key: thirdPartyDataSharingInformation
     requirements: The consumer understands and accepts how their information is shared with, or accessible by, third party suppliers and their supply chains.
     filters: The consumer understands and accepts how their information is shared with, or accessible by, third party suppliers and their supply chains.
     hint: "Do you inform consumers how much of their information is shared with, or accessible by, third-party suppliers and their supply chains?"
@@ -10,6 +11,7 @@ Supply-chain security:
         filterLabel: Visibility of data shared with third-party suppliers
     validationNotAnswered: "This question requires an answer."
   "Third-party supplier security requirements":
+    key: thirdPartySecurityRequirements
     requirements: The consumer understands and accepts how the service provider’s procurement processes place security requirements on third party suppliers and delivery partners.
     filters: The consumer understands and accepts how the service provider’s procurement processes place security requirements on third party suppliers and delivery partners.
     hint: "Do you ensure that relevant security requirements, such as the Cloud Security Principles, are placed on third-party suppliers and delivery partners?"
@@ -20,6 +22,7 @@ Supply-chain security:
         filterLabel: Third-party supplier security requirements
     validationNotAnswered: "This question requires an answer."
   "Third-party supplier risk assessment":
+    key: thirdPartyRiskAssessment
     requirements: The consumer understands and accepts how the service provider manages security risks from third party suppliers and delivery partners.
     filters: The consumer understands and accepts how the service provider manages security risks from third party suppliers and delivery partners.
     hint: "Do you manage the risks to your service from third-party suppliers and delivery partners?"
@@ -30,6 +33,7 @@ Supply-chain security:
         filterLabel: Third-party supplier risk assessment
     validationNotAnswered: "This question requires an answer."
   "Third-party supplier compliance monitoring":
+    key: thirdPartyComplianceMonitoring
     requirements: The consumer understands and accepts how the service provider manages the conformance of their suppliers with security requirements.
     filters: The consumer understands and accepts how the service provider manages the conformance of their suppliers with security requirements.
     hint: "Do you manage your third-party suppliers' compliance with relevant security requirements?"
@@ -40,6 +44,7 @@ Supply-chain security:
         filterLabel: Third-party supplier compliance monitoring
     validationNotAnswered: "This question requires an answer."
   "Hardware and software verification":
+    key: hardwareSoftwareVerification
     requirements: The consumer understands and accepts how the service provider verifies that hardware and software used in the service is genuine and has not been tampered with.
     filters: The consumer understands and accepts how the service provider verifies that hardware and software used in the service is genuine and has not been tampered with.
     hint: "Do you verify that the hardware and software used in the service are genuine and have not been obviously tampered with?"

--- a/service/security/vulnerability-management.yml
+++ b/service/security/vulnerability-management.yml
@@ -1,5 +1,6 @@
 Vulnerabilility management:
   "Vulnerability assessment":
+    key: vulnerabilityAssessment
     requirements: Consumers should have confidence that potential new threats, vulnerabilities or exploitation techniques which could affect the service are assessed and corrective action is taken.
     filters: Consumers should have confidence that potential new threats, vulnerabilities or exploitation techniques which could affect the service are assessed and corrective action is taken.
     hint: "Are potential threats, vulnerabilities or exploitation techniques which could affect the service assessed, and are corrective actions taken?"
@@ -10,6 +11,7 @@ Vulnerabilility management:
         filterLabel: Vulnerability assessment
     validationNotAnswered: "This question requires an answer."
   "Vulnerability monitoring":
+    key: vulnerabilityMonitoring
     requirements: Consumers should have confidence that relevant sources of information relating to threat, vulnerability and exploitation technique information are monitored by the service provider.
     filters: Consumers should have confidence that relevant sources of information relating to threat, vulnerability and exploitation technique information are monitored by the service provider.
     hint: "Do you monitor relevant sources of information relating to threat, vulnerability and exploitation techniques?"
@@ -20,6 +22,7 @@ Vulnerabilility management:
         filterLabel: Vulnerability monitoring
     validationNotAnswered: "This question requires an answer."
   "Vulnerability mitigation prioritisation":
+    key: vulnerabilityMitigationPrioritisation
     requirements: Consumers should have confidence that the severity of threats and vulnerabilities are considered within the context of the service and this information is used to prioritise implementation of mitigations.
     filters: Consumers should have confidence that the severity of threats and vulnerabilities are considered within the context of the service and this information is used to prioritise implementation of mitigations.
     hint: "Is the severity of threats and vulnerabilities considered and do you use this information to prioritise implementation of mitigations?"
@@ -30,6 +33,7 @@ Vulnerabilility management:
         filterLabel: Vulnerability mitigation prioritisation
     validationNotAnswered: "This question requires an answer."
   "Vulnerability tracking":
+    key: vulnerabilityTracking
     requirements: Consumers should have confidence that known vulnerabilities within the service are tracked until suitable mitigations have been deployed through a suitable change management process.
     filters: Consumers should have confidence that known vulnerabilities within the service are tracked until suitable mitigations have been deployed through a suitable change management process.
     hint: "Are known vulnerabilities within the service tracked until suitable mitigations have been deployed?"
@@ -40,6 +44,7 @@ Vulnerabilility management:
         filterLabel: Vulnerability tracking
     validationNotAnswered: "This question requires an answer."
   "Vulnerability mitigation timescales":
+    key: vulnerabilityTimescales
     requirements: Consumers should have confidence that service provider timescales for implementing mitigations to vulnerabilities found within the service are made available to them.
     filters: Consumers should have confidence that service provider timescales for implementing mitigations to vulnerabilities found within the service are made available to them.
     hint: "Do you make timescales available for implementing mitigations to vulnerabilities?"

--- a/service/service-definition.yml
+++ b/service/service-definition.yml
@@ -1,5 +1,6 @@
 Service definition:
   Service definition document:
+    key: serviceDefinitionDocument
     hint: "Please upload your service definition. Refer to the ITT documentation for further guidance on what to include. This document will not be indexed by search on the Digital Marketplace. Use an Open Document Format (ODF) or PDF/A (eg .pdf, .odt). (Maximum file size 5MB.)"
     mockAnswer: Umbraco Service_Definition 102014.odf
     dependsOnLots: SaaS, PaaS, IaaS, SCS

--- a/service/service-description.yml
+++ b/service/service-description.yml
@@ -1,5 +1,6 @@
 Service description:
   Service name:
+    key: serviceName
     hint: "Include your product name only. Using additional keywords may impact your acceptance on to the Digital Marketplace."
     mockAnswer: Umbraco CMS
     dependsOnLots: SaaS, PaaS, IaaS, SCS
@@ -7,6 +8,7 @@ Service description:
       - type: text
     validationNotAnswered: "This question requires an answer."
   Service summary:
+    key: serviceSummary
     hint: "Please provide a short description of your service. (Maximum 50 words.) You'll be asked to go into more detail about the features and benefits of your service on the next page. Company information should not be included here. You can provide a company description for your supplier page elsewhere."
     mockAnswer: "Professional website development to enhance the delivery and performance of online services based on Sitecore or Umbraco Content Management Systems. We provide development and support services for large scale, business critical websites for many organisations including NHS Direct, Department for Education and the Department for Business, Innovation and Skills."
     dependsOnLots: SaaS, PaaS, IaaS, SCS

--- a/service/service-type-IaaS.yml
+++ b/service/service-type-IaaS.yml
@@ -1,5 +1,6 @@
 Service type:
   Choose the categories that apply to your service:
+    key: serviceTypes
     dependsOnLots: IaaS
     hint: "You can choose multiple categories."
     mockAnswer: Compute

--- a/service/service-type-SCS.yml
+++ b/service/service-type-SCS.yml
@@ -1,5 +1,6 @@
 Service type:
   Choose the categories that apply to your service:
+    key: serviceTypes
     dependsOnLots: SCS
     hint: "You can choose multiple categories"
     mockAnswer: Content management system

--- a/service/service-type-SaaS.yml
+++ b/service/service-type-SaaS.yml
@@ -1,5 +1,6 @@
 Service type:
   Choose the categories that apply to your service:
+    id: serviceTypes
     dependsOnLots: SaaS
     hint: "You can choose multiple categories"
     mockAnswer: Content management system

--- a/service/support.yml
+++ b/service/support.yml
@@ -1,5 +1,6 @@
 Support:
   Support service type:
+    key: supportTypes
     dependsOnLots: SaaS, PaaS, IaaS, SCS
     hint: Choose all that apply.
     fields:
@@ -20,24 +21,28 @@ Support:
         filterLabel: Onsite
     validationNotAnswered: "This question requires an answer."
   Support accessible to any third-party suppliers:
+    key: supportForThirdParties
     dependsOnLots: SaaS, PaaS, IaaS, SCS
     fields:
       - type: boolean
         filterLabel: Support accessible to any third-party suppliers
     validationNotAnswered: "This question requires an answer."
   Support availablility:
+    key: supportAvailability
     dependsOnLots: SaaS, PaaS, IaaS, SCS
     hint: "eg 24/7 or 9 to 5. (Maximum 20 words.)"
     fields:
       - type: text
     validationNotAnswered: "This question requires an answer."
   Standard support response times:
+    key: supportResponseTime
     dependsOnLots: SaaS, PaaS, IaaS, SCS
     hint: "How long will it take until support can begin to be provided? eg 1 hour or 1 business day. (Maximum 20 words.)"
     fields:
       - type: text
     validationNotAnswered: "This question requires an answer."
   Incident escalation process available:
+    key: incidentEscalation
     dependsOnLots: SaaS, PaaS, IaaS, SCS
     fields:
       - type: boolean

--- a/service/terms-and-conditions.yml
+++ b/service/terms-and-conditions.yml
@@ -1,11 +1,13 @@
 Terms and conditions:
   Termination cost:
+    key: terminationCost
     dependsOnLots: PaaS, IaaS, SCS
     fields:
       - type: boolean
         filterLabel: Termination cost
     validationNotAnswered: "This question requires an answer."
   Minimum contract period:
+    key: minimumContractPeriod
     dependsOnLots: SaaS, PaaS, IaaS, SCS
     fields:
       - type: radio
@@ -24,6 +26,7 @@ Terms and conditions:
         label: "Other"
     validationNotAnswered: "This question requires an answer."
   Please upload your terms and conditions document:
+    key: termsAndConditionsDocument
     mockAnswer: Umbraco Terms_Conditions 102014.odf
     dependsOnLots: SaaS, PaaS, IaaS, SCS
     hint: "Please upload your terms and conditions document. This document will not be indexed by search on the Digital Marketplace. Use an Open Document Format (ODF) or PDF/A (eg .pdf, .odt). (Maximum file size 5MB.)"


### PR DESCRIPTION
Based on the mapping here: https://github.com/alphagov/supplier-submission-portal/blob/master/app/uk/gov/gds/dm/KeyMapper.java

This lets any other app look up data from this content. There is lots of good stuff in this repo, including, but not limited to:
- The name of a question
- The validation messages that the SSP used
- The label of a question when it's presented as a filter
- Which questions depend on which lots
- Whether individual options (e.g. EU, UK, USA, other) should be displayed as filters

Adding these keys means that any app that currently speaks these keys (Thermos, data API) will be able to make use of the content.

There may be a better way of managing information than this repo, but for now I think the keys give an abstraction that would allow the easy swapping-out of a different format of content.