### PR TITLE
Flatten fields object

### DIFF
--- a/g6/analyticsAvailable.yml
+++ b/g6/analyticsAvailable.yml
@@ -1,7 +1,5 @@
 dependsOnLots: 'SaaS, PaaS, IaaS'
-fields:
-    -
-        type: boolean
-        filterLabel: 'Real-time management information available'
+type: boolean
+filterLabel: 'Real-time management information available'
 validationNotAnswered: 'This question requires an answer.'
 question: 'Real-time management information available'

--- a/g6/apiAccess.yml
+++ b/g6/apiAccess.yml
@@ -1,7 +1,5 @@
 dependsOnLots: 'SaaS, PaaS, IaaS'
-fields:
-    -
-        type: boolean
-        filterLabel: 'API access available and supported'
+type: boolean
+filterLabel: 'API access available and supported'
 validationNotAnswered: 'This question requires an answer.'
 question: 'API access available and supported'

--- a/g6/apiType.yml
+++ b/g6/apiType.yml
@@ -1,7 +1,5 @@
 dependsOnLots: 'SaaS, PaaS, IaaS'
 hint: 'Examples of API include RESTful and SOAP.'
-fields:
-    -
-        type: text
+type: text
 validationNotAnswered: 'This question requires an answer.'
 question: 'API type'

--- a/g6/auditInformationProvided.yml
+++ b/g6/auditInformationProvided.yml
@@ -3,16 +3,14 @@ filters: 'Consumers are aware of the audit information that will be provided to 
 hint: 'Do you provide audit information to consumers? Choose 1.'
 dependsOnLots: 'SaaS, PaaS, IaaS'
 assuranceApproach: 2answers-type1
-fields:
+type: radios
+options:
     -
-        type: radio
         label: None
     -
-        type: radio
         label: 'Data made available'
         filterLabel: 'Data made available'
     -
-        type: radio
         label: 'Data made available by negotiation'
         filterLabel: 'Data made available by negotiation'
 validationNotAnswered: 'This question requires an answer.'

--- a/g6/changeImpactAssessment.yml
+++ b/g6/changeImpactAssessment.yml
@@ -3,9 +3,7 @@ filters: 'Consumers should have confidence that changes to the service are asses
 hint: 'Are changes to the service assessed for potential security impact, and are changes managed and tracked through to completion?'
 dependsOnLots: 'SaaS, PaaS, IaaS'
 assuranceApproach: 2answers-type1
-fields:
-    -
-        type: boolean
-        filterLabel: 'Change impact assessment'
+type: boolean
+filterLabel: 'Change impact assessment'
 validationNotAnswered: 'This question requires an answer.'
 question: 'Change impact assessment'

--- a/g6/cloudDeploymentModel.yml
+++ b/g6/cloudDeploymentModel.yml
@@ -3,21 +3,18 @@ filters: 'Service providers must state whether the service is a public, private 
 hint: 'Is the service a public, private, community or hybrid cloud service?'
 dependsOnLots: 'SaaS, PaaS, IaaS'
 assuranceApproach: 3answers-type1
-fields:
+type: radios
+options:
     -
-        type: radio
         label: 'Public cloud'
         filterLabel: 'Public cloud'
     -
-        type: radio
         label: 'Community cloud'
         filterLabel: 'Community cloud'
     -
-        type: radio
         label: 'Private cloud'
         filterLabel: 'Private cloud'
     -
-        type: radio
         label: 'Hybrid cloud'
         filterLabel: 'Hybrid cloud'
 validationNotAnswered: 'This question requires an answer.'

--- a/g6/codeLibraryLanguages.yml
+++ b/g6/codeLibraryLanguages.yml
@@ -1,8 +1,6 @@
 dependsOnLots: SaaS
 hint: 'Examples of code libraries include AWS Ruby SDK and Stripe-Java. Examples of languages include PHP and Python. (Maximum 10 languages.) (Optional.) '
 listItemName: 'code libraries example'
-fields:
-    -
-        type: list
-        addthing: 'Add another code library'
+type: list
+addthing: 'Add another code library'
 question: 'Languages your code libraries are written in'

--- a/g6/configurationTracking.yml
+++ b/g6/configurationTracking.yml
@@ -3,9 +3,7 @@ filters: 'Consumers should have confidence that the status, location and configu
 hint: 'Do you track the status, location and configuration of service components throughout their lifetime?'
 dependsOnLots: 'PaaS, IaaS'
 assuranceApproach: 2answers-type1
-fields:
-    -
-        type: boolean
-        filterLabel: 'Configuration and change management tracking'
+type: boolean
+filterLabel: 'Configuration and change management tracking'
 validationNotAnswered: 'This question requires an answer.'
 question: 'Configuration and change management tracking'

--- a/g6/dataAtRestProtection.yml
+++ b/g6/dataAtRestProtection.yml
@@ -3,29 +3,24 @@ filters: 'Consumers should have sufficient confidence that storage media contain
 hint: 'How is storage media containing consumer data protected from unauthorised physical access? Choose 1.'
 dependsOnLots: 'SaaS, PaaS, IaaS'
 assuranceApproach: 4answers-type1
-fields:
+type: radios
+options:
     -
-        type: radio
         label: 'CPA Foundation-grade assured components'
         filterLabel: 'CPA Foundation-grade assured components'
     -
-        type: radio
         label: 'FIPS-assured encryption'
         filterLabel: 'FIPS-assured encryption'
     -
-        type: radio
         label: 'Other encryption'
         filterLabel: 'Other encryption'
     -
-        type: radio
         label: 'Secure containers, racks or cages'
         filterLabel: 'Secure containers, racks or cages'
     -
-        type: radio
         label: 'Physical access control'
         filterLabel: 'Physical access control'
     -
-        type: radio
         label: 'No protection'
 validationNotAnswered: 'This question requires an answer.'
 question: 'Data-at-rest protection'

--- a/g6/dataBackupRecovery.yml
+++ b/g6/dataBackupRecovery.yml
@@ -2,9 +2,7 @@ dependsOnLots: 'SaaS, PaaS, IaaS'
 servicePageLabel: 'Backup, disaster recovery and resilience plan in place'
 assuranceApproach: null
 hint: 'You can provide more detail on your disaster recovery plan in your service definition document.'
-fields:
-    -
-        type: boolean
-        filterLabel: 'Backup, disaster recovery and resilience plan in place'
+type: boolean
+filterLabel: 'Backup, disaster recovery and resilience plan in place'
 validationNotAnswered: 'Please answer if plans for backup, disaster recovery and resilience are in place'
 question: 'Backup, disaster recovery and resilience plan in place'

--- a/g6/dataExtractionRemoval.yml
+++ b/g6/dataExtractionRemoval.yml
@@ -1,9 +1,7 @@
 dependsOnLots: 'SaaS, PaaS, IaaS'
 servicePageLabel: 'Data extraction/removal plan in place'
 assuranceApproach: null
-fields:
-    -
-        type: boolean
-        filterLabel: 'Data extraction/removal plan in place'
+type: boolean
+filterLabel: 'Data extraction/removal plan in place'
 validationNotAnswered: 'This question requires an answer.'
 question: 'Data extraction/removal plan in place'

--- a/g6/dataManagementLocations.yml
+++ b/g6/dataManagementLocations.yml
@@ -3,25 +3,21 @@ filters: 'The geographic location(s) where consumer data is stored, processed or
 hint: 'Where are the services managed from? Choose all that apply.'
 dependsOnLots: 'SaaS, PaaS, IaaS'
 assuranceApproach: 3answers-type1
-fields:
+type: checkboxes
+options:
     -
-        type: checkbox
         label: UK
         filterLabel: UK
     -
-        type: checkbox
         label: EU
         filterLabel: EU
     -
-        type: checkbox
         label: 'USA - Safe Harbor'
         filterLabel: 'USA - Safe Harbor'
     -
-        type: checkbox
         label: 'Other countries with data protection treaties'
         filterLabel: 'Other countries with data protection treaties'
     -
-        type: checkbox
         label: 'Rest of world'
 validationNotAnswered: 'This question requires an answer.'
 question: 'Data management location'

--- a/g6/dataProtctionWithinService.yml
+++ b/g6/dataProtctionWithinService.yml
@@ -3,29 +3,24 @@ filters: 'Data in transit is protected internally within the service'
 hint: 'Choose 1'
 dependsOnLots: 'PaaS, IaaS'
 assuranceApproach: 4answers-type1
-fields:
+type: radios
+options:
     -
-        type: radio
         label: 'VPN using TLS, version 1.2 or later'
         filterLabel: 'VPN using TLS, version 1.2 or later'
     -
-        type: radio
         label: 'VPN using legacy SSL or TLS'
         filterLabel: 'VPN using legacy SSL or TLS'
     -
-        type: radio
         label: VLAN
         filterLabel: VLAN
     -
-        type: radio
         label: 'Bonded fibre optic connections'
         filterLabel: 'Bonded fibre optic connections'
     -
-        type: radio
         label: 'Other network protection'
         filterLabel: 'Other network protection'
     -
-        type: radio
         label: 'No encryption'
 validationNotAnswered: 'This question requires an answer.'
 question: 'Data protection within service'

--- a/g6/dataProtectionBetweenServices.yml
+++ b/g6/dataProtectionBetweenServices.yml
@@ -3,29 +3,24 @@ filters: 'Data in transit is protected between the service and other services (e
 hint: 'Choose 1'
 dependsOnLots: 'PaaS, IaaS'
 assuranceApproach: 4answers-type1
-fields:
+type: radios
+options:
     -
-        type: radio
         label: 'Encrypted PSN service'
         filterLabel: 'Encrypted PSN service'
     -
-        type: radio
         label: 'PSN service'
         filterLabel: 'PSN service'
     -
-        type: radio
         label: 'CPA Foundation VPN Gateway'
         filterLabel: 'CPA Foundation VPN Gateway'
     -
-        type: radio
         label: 'VPN using TLS, version 1.2 or later'
         filterLabel: 'VPN using TLS, version 1.2 or later'
     -
-        type: radio
         label: 'VPN using legacy SSL or TLS'
         filterLabel: 'VPN using legacy SSL or TLS'
     -
-        type: radio
         label: 'No encryption'
 validationNotAnswered: 'This question requires an answer.'
 question: 'Data protection between services'

--- a/g6/dataProtectionBetweenUserAndService.yml
+++ b/g6/dataProtectionBetweenUserAndService.yml
@@ -4,29 +4,24 @@ hint: 'Choose 1'
 dependsOnLots: 'SaaS, PaaS, IaaS'
 assuranceApproach: 4answers-type1
 assuranceHint: 'How can you support the above answer?'
-fields:
+type: radios
+options:
     -
-        type: radio
         label: 'Encrypted PSN service'
         filterLabel: 'Encrypted PSN service'
     -
-        type: radio
         label: 'PSN service'
         filterLabel: 'PSN service'
     -
-        type: radio
         label: 'CPA Foundation VPN Gateway'
         filterLabel: 'CPA Foundation VPN Gateway'
     -
-        type: radio
         label: 'VPN using TLS, version 1.2 or later'
         filterLabel: 'VPN using TLS, version 1.2 or later'
     -
-        type: radio
         label: 'VPN using legacy SSL or TLS'
         filterLabel: 'VPN using legacy SSL or TLS'
     -
-        type: radio
         label: 'No encryption'
 validationNotAnswered: 'This question requires an answer.'
 question: 'Data protection between user device and service'

--- a/g6/dataRedundantEquipmentAccountsRevoked.yml
+++ b/g6/dataRedundantEquipmentAccountsRevoked.yml
@@ -3,9 +3,7 @@ filters: 'Consumers should be sufficiently confident that accounts or credential
 hint: 'Are accounts or credentials specific to redundant equipment revoked to reduce their value to an attacker?'
 dependsOnLots: 'PaaS, IaaS'
 assuranceApproach: 3answers-type1
-fields:
-    -
-        type: boolean
-        filterLabel: 'Redundant equipment accounts revoked'
+type: boolean
+filterLabel: 'Redundant equipment accounts revoked'
 validationNotAnswered: 'This question requires an answer.'
 question: 'Redundant equipment accounts revoked'

--- a/g6/dataSecureDeletion.yml
+++ b/g6/dataSecureDeletion.yml
@@ -3,21 +3,18 @@ filters: 'Consumers should be sufficiently confident that their data is erased w
 hint: 'How do you erase consumer data when resources are moved or re-provisioned, or when the consumer leaves the service, or when they request it to be erased? Choose 1.'
 dependsOnLots: 'SaaS, PaaS, IaaS'
 assuranceApproach: 4answers-type1
-fields:
+type: radios
+options:
     -
-        type: radio
         label: 'CPA Foundation-grade erasure product'
         filterLabel: 'CPA Foundation-grade erasure product'
     -
-        type: radio
         label: 'CESG or CPNI-approved erasure process'
         filterLabel: 'CESG or CPNI-approved erasure process'
     -
-        type: radio
         label: 'Other secure erasure process'
         filterLabel: 'Other secure erasure process'
     -
-        type: radio
         label: 'Other erasure process'
 validationNotAnswered: 'This question requires an answer.'
 question: 'Secure data deletion'

--- a/g6/dataSecureEquipmentDisposal.yml
+++ b/g6/dataSecureEquipmentDisposal.yml
@@ -3,9 +3,7 @@ filters: 'Consumers should be sufficiently confident that all equipment potentia
 hint: 'Is all equipment potentially containing consumer data, credentials or configuration information identified at the end of its life or prior to being recycled? Choose 1.'
 dependsOnLots: 'PaaS, IaaS'
 assuranceApproach: 4answers-type2
-fields:
-    -
-        type: boolean
-        filterLabel: 'Secure equipment disposal'
+type: boolean
+filterLabel: 'Secure equipment disposal'
 validationNotAnswered: 'This question requires an answer.'
 question: 'Secure equipment disposal'

--- a/g6/dataStorageMediaDisposal.yml
+++ b/g6/dataStorageMediaDisposal.yml
@@ -3,33 +3,27 @@ filters: 'Consumers should be sufficiently confident that storage media which ha
 hint: 'How is storage media containing consumer data sanitised or securely destroyed at the end of its usable lifetime? Choose 1.'
 dependsOnLots: 'PaaS, IaaS'
 assuranceApproach: 5answers-type1
-fields:
+type: radios
+options:
     -
-        type: radio
         label: 'CESG-assured destruction service (CAS(T))'
         filterLabel: 'CESG-assured destruction service (CAS(T))'
     -
-        type: radio
         label: 'CPA Foundation-assured product'
         filterLabel: 'CPA Foundation-assured product'
     -
-        type: radio
         label: 'CPNI-approved destruction service'
         filterLabel: 'CPNI-approved destruction service'
     -
-        type: radio
         label: 'BS EN 151713:2009-compliant destruction'
         filterLabel: 'BS EN 151713:2009-compliant destruction'
     -
-        type: radio
         label: 'CESG or CPNI-approved erasure process'
         filterLabel: 'CESG or CPNI-approved erasure process'
     -
-        type: radio
         label: 'Other secure erasure process'
         filterLabel: 'Other secure erasure process'
     -
-        type: radio
         label: 'Other destruction/erasure process'
 validationNotAnswered: 'This question requires an answer.'
 question: 'Storage media disposal'

--- a/g6/datacentreLocations.yml
+++ b/g6/datacentreLocations.yml
@@ -3,25 +3,21 @@ filters: 'The geographic location(s) where consumer data is stored, processed or
 hint: 'Where are the service provider''s datacentres located? Choose all that apply.'
 dependsOnLots: 'SaaS, PaaS, IaaS'
 assuranceApproach: 3answers-type1
-fields:
+type: checkboxes
+options:
     -
-        type: checkbox
         label: UK
         filterLabel: UK
     -
-        type: checkbox
         label: EU
         filterLabel: EU
     -
-        type: checkbox
         label: 'USA - Safe Harbor'
         filterLabel: 'USA - Safe Harbor'
     -
-        type: checkbox
         label: 'Other countries with data protection treaties'
         filterLabel: 'Other countries with data protection treaties'
     -
-        type: checkbox
         label: 'Rest of world'
 validationNotAnswered: 'This question requires an answer.'
 question: 'Datacentre location'

--- a/g6/datacentreProtectionDisclosure.yml
+++ b/g6/datacentreProtectionDisclosure.yml
@@ -3,9 +3,7 @@ filters: 'Consumers should be confident that the physical security measures empl
 hint: 'Do you tell your consumers what physical security your datacentres have?'
 dependsOnLots: 'SaaS, PaaS, IaaS'
 assuranceApproach: 3answers-type1
-fields:
-    -
-        type: boolean
-        filterLabel: 'Datacentre protection'
+type: boolean
+filterLabel: 'Datacentre protection'
 validationNotAnswered: 'This question requires an answer.'
 question: 'Datacentre protection'

--- a/g6/datacentreTier.yml
+++ b/g6/datacentreTier.yml
@@ -2,42 +2,33 @@ hint: 'Choose one'
 dependsOnLots: 'SaaS, PaaS, IaaS'
 servicePageLabel: 'Datacentre tier'
 assuranceApproach: null
-fields:
+type: radio
+options:
     -
-        type: radio
         label: 'TIA-942 Tier 1'
         filterLabel: 'TIA-942 Tier 1 datacentre'
-        displayedResponse: 'TIA-942 Tier 1'
     -
-        type: radio
         label: 'TIA-942 Tier 2'
         filterLabel: 'TIA-942 Tier 2 datacentre'
     -
-        type: radio
         label: 'TIA-942 Tier 3'
         filterLabel: 'TIA-942 Tier 3 datacentre'
     -
-        type: radio
         label: 'TIA-942 Tier 4'
         filterLabel: 'TIA-942 Tier 4 datacentre'
     -
-        type: radio
         label: 'Uptime Institute Tier 1'
         filterLabel: 'Uptime Institute Tier 1 datacentre'
     -
-        type: radio
         label: 'Uptime Institute Tier 2'
         filterLabel: 'Uptime Institute Tier 2 datacentre'
     -
-        type: radio
         label: 'Uptime Institute Tier 3'
         filterLabel: 'Uptime Institute Tier 3 datacentre'
     -
-        type: radio
         label: 'Uptime Institute Tier 4'
         filterLabel: 'Uptime Institute Tier 4 datacentre'
     -
-        type: radio
         label: 'None of the above'
 validationNotAnswered: 'This question requires an answer.'
 question: 'Datacentre tier'

--- a/g6/datacentresEUCode.yml
+++ b/g6/datacentresEUCode.yml
@@ -2,9 +2,7 @@ dependsOnLots: 'SaaS, PaaS, IaaS'
 servicePageLabel: 'Datacentres adhere to EU Code of Conduct for Operations'
 assuranceApproach: null
 assuranceHint: null
-fields:
-    -
-        type: boolean
-        filterLabel: 'Datacentres adhere to EU Code of Conduct for Operations'
+type: boolean
+filterLabel: 'Datacentres adhere to EU Code of Conduct for Operations'
 validationNotAnswered: 'This question requires an answer.'
 question: 'Datacentres adhere to EU Code of Conduct for Operations'

--- a/g6/datacentresSpecifyLocation.yml
+++ b/g6/datacentresSpecifyLocation.yml
@@ -1,9 +1,7 @@
 dependsOnLots: 'SaaS, PaaS, IaaS'
 servicePageLabel: 'User-defined data location'
 assuranceApproach: null
-fields:
-    -
-        type: boolean
-        filterLabel: 'User-defined data location'
+type: boolean
+filterLabel: 'User-defined data location'
 validationNotAnswered: 'This question requires an answer.'
 question: 'User-defined data location'

--- a/g6/deprovisioningTime.yml
+++ b/g6/deprovisioningTime.yml
@@ -1,7 +1,5 @@
 dependsOnLots: 'SaaS, PaaS, IaaS'
 hint: ""
-fields:
-    -
-        type: text
+type: text
 validationNotAnswered: 'This question requires an answer.'
 question: 'Service deprovisioning time'

--- a/g6/deviceAccessMethod.yml
+++ b/g6/deviceAccessMethod.yml
@@ -3,17 +3,15 @@ filters: 'The consumer understands any service configuration options available t
 hint: 'Which end device is the cloud service accessible from?'
 dependsOnLots: 'SaaS, PaaS, IaaS'
 assuranceApproach: 2answers-type1
-fields:
+type: radios
+options:
     -
-        type: radio
         label: 'Corporate/enterprise devices'
         filterLabel: 'Corporate/enterprise devices'
     -
-        type: radio
         label: 'Partner devices'
         filterLabel: 'Partner devices'
     -
-        type: radio
         label: 'Unknown devices'
         filterLabel: 'Unknown devices'
 validationNotAnswered: 'This question requires an answer.'

--- a/g6/educationPricing.yml
+++ b/g6/educationPricing.yml
@@ -1,8 +1,6 @@
 dependsOnLots: 'SaaS, PaaS, IaaS, SCS'
 hint: 'Do you offer special pricing for educational organisations?'
-fields:
-    -
-        type: boolean
-        filterLabel: 'Education pricing'
+type: boolean
+filterLabel: 'Education pricing'
 validationNotAnswered: 'This question requires an answer.'
 question: 'Education pricing'

--- a/g6/elasticCloud.yml
+++ b/g6/elasticCloud.yml
@@ -1,7 +1,5 @@
 dependsOnLots: 'SaaS, PaaS, IaaS'
-fields:
-    -
-        type: boolean
-        filterLabel: 'Elastic cloud approach supported'
+type: boolean
+filterLabel: 'Elastic cloud approach supported'
 validationNotAnswered: 'This question requires an answer.'
 question: 'Elastic cloud approach supported'

--- a/g6/eventMonitoring.yml
+++ b/g6/eventMonitoring.yml
@@ -3,9 +3,7 @@ filters: 'Consumers should have confidence that events generated in service comp
 hint: 'Do you conduct event monitoring and analysis to identify suspicious activity?'
 dependsOnLots: 'SaaS, PaaS, IaaS'
 assuranceApproach: 2answers-type1
-fields:
-    -
-        type: boolean
-        filterLabel: 'Event monitoring'
+type: boolean
+filterLabel: 'Event monitoring'
 validationNotAnswered: 'This question requires an answer.'
 question: 'Event monitoring'

--- a/g6/freeOption.yml
+++ b/g6/freeOption.yml
@@ -1,7 +1,5 @@
 dependsOnLots: 'SaaS, PaaS, IaaS'
-fields:
-    -
-        type: boolean
-        filterLabel: 'Free option'
+type: boolean
+filterLabel: 'Free option'
 validationNotAnswered: 'This question requires an answer.'
 question: 'Free option'

--- a/g6/governanceFramework.yml
+++ b/g6/governanceFramework.yml
@@ -3,9 +3,7 @@ filters: 'The consumer should have sufficient confidence that the governance fra
 hint: 'Do you have a governance framework and process in place for the service, eg ISO277001:2013?'
 dependsOnLots: 'SaaS, PaaS, IaaS'
 assuranceApproach: 2answers-type1
-fields:
-    -
-        type: boolean
-        filterLabel: 'Governance framework'
+type: boolean
+filterLabel: 'Governance framework'
 validationNotAnswered: 'This question requires an answer.'
 question: 'Governance framework'

--- a/g6/guaranteedResources.yml
+++ b/g6/guaranteedResources.yml
@@ -1,7 +1,5 @@
 dependsOnLots: 'SaaS, PaaS, IaaS'
-fields:
-    -
-        type: boolean
-        filterLabel: 'Guaranteed resources defined'
+type: boolean
+filterLabel: 'Guaranteed resources defined'
 validationNotAnswered: 'This question requires an answer.'
 question: 'Guaranteed resources defined'

--- a/g6/hardwareSoftwareVerification.yml
+++ b/g6/hardwareSoftwareVerification.yml
@@ -3,9 +3,7 @@ filters: 'The consumer understands and accepts how the service provider verifies
 hint: 'Do you verify that the hardware and software used in the service are genuine and have not been obviously tampered with?'
 dependsOnLots: 'PaaS, IaaS'
 assuranceApproach: 2answers-type1
-fields:
-    -
-        type: boolean
-        filterLabel: 'Hardware and software verification'
+type: boolean
+filterLabel: 'Hardware and software verification'
 validationNotAnswered: 'This question requires an answer.'
 question: 'Hardware and software verification'

--- a/g6/identityAuthenticationControls.yml
+++ b/g6/identityAuthenticationControls.yml
@@ -3,33 +3,27 @@ filters: 'Consumers should have sufficient confidence that identity and authenti
 hint: 'How do your identity and authentication controls ensure that users are authorised to access specific interfaces? Choose all that apply.'
 dependsOnLots: 'SaaS, PaaS, IaaS'
 assuranceApproach: 3answers-type3
-fields:
+type: checkboxes
+options:
     -
-        type: checkbox
         label: 'Username and two-factor authentication'
         filterLabel: 'Username and two-factor authentication'
     -
-        type: checkbox
         label: 'Username and TLS client certificate'
         filterLabel: 'Username and TLS client certificate'
     -
-        type: checkbox
         label: 'Authentication federation'
         filterLabel: 'Authentication federation'
     -
-        type: checkbox
         label: 'Limited access over dedicated link, enterprise or community network'
         filterLabel: 'Limited access over dedicated link, enterprise or community network'
     -
-        type: checkbox
         label: 'Username and password'
         filterLabel: 'Username and password'
     -
-        type: checkbox
         label: 'Username and strong password/passphrase enforcement'
         filterLabel: 'Username and strong password/passphrase enforcement'
     -
-        type: checkbox
         label: 'Other mechanism'
 validationNotAnswered: 'This question requires an answer.'
 question: 'Identity and authentication controls'

--- a/g6/identityStandards.yml
+++ b/g6/identityStandards.yml
@@ -1,8 +1,6 @@
 dependsOnLots: SaaS
 hint: 'Examples of identity standards include OAuth and SAML. (Optional.)'
 listItemName: 'identity standards example'
-fields:
-    -
-        type: list
-        addthing: 'Add another standard'
+type: list
+addthing: 'Add another standard'
 question: 'Identity standards your service uses'

--- a/g6/incidentDefinitionPublished.yml
+++ b/g6/incidentDefinitionPublished.yml
@@ -3,9 +3,7 @@ filters: 'Consumers should have confidence that a defined process and contact ro
 dependsOnLots: 'SaaS, PaaS, IaaS'
 assuranceApproach: 2answers-type1
 hint: 'Do you publish to consumers your definition of a security incident, along with the format, incident triggers and timescales for reporting such incidents?'
-fields:
-    -
-        type: boolean
-        filterLabel: 'Security incident definition published'
+type: boolean
+filterLabel: 'Security incident definition published'
 validationNotAnswered: 'This question requires an answer.'
 question: 'Security incident definition published'

--- a/g6/incidentEscalation.yml
+++ b/g6/incidentEscalation.yml
@@ -1,7 +1,5 @@
 dependsOnLots: 'SaaS, PaaS, IaaS, SCS'
-fields:
-    -
-        type: boolean
-        filterLabel: 'Incident escalation process available'
+type: boolean
+filterLabel: 'Incident escalation process available'
 validationNotAnswered: 'This question requires an answer.'
 question: 'Incident escalation process available'

--- a/g6/incidentManagementProcess.yml
+++ b/g6/incidentManagementProcess.yml
@@ -3,9 +3,7 @@ filters: 'Consumers should have confidence that incident management processes ar
 hint: 'Do you have incident management processes in place and are they enacted in response to security incidents?'
 dependsOnLots: 'SaaS, PaaS, IaaS'
 assuranceApproach: 2answers-type1
-fields:
-    -
-        type: boolean
-        filterLabel: 'Incident management processes'
+type: boolean
+filterLabel: 'Incident management processes'
 validationNotAnswered: 'This question requires an answer.'
 question: 'Incident management processes'

--- a/g6/incidentManagementReporting.yml
+++ b/g6/incidentManagementReporting.yml
@@ -3,9 +3,7 @@ filters: 'Consumers should have confidence that pre-defined processes are in pla
 hint: 'Do you have a defined process for reporting security incidents experienced by consumers and external entities?'
 dependsOnLots: 'SaaS, PaaS, IaaS'
 assuranceApproach: 2answers-type1
-fields:
-    -
-        type: boolean
-        filterLabel: 'Consumer reporting of security incidents'
+type: boolean
+filterLabel: 'Consumer reporting of security incidents'
 validationNotAnswered: 'This question requires an answer.'
 question: 'Consumer reporting of security incidents'

--- a/g6/interconnectionMethods.yml
+++ b/g6/interconnectionMethods.yml
@@ -3,21 +3,18 @@ filters: 'The consumer understands what physical and logical interfaces their in
 hint: 'What method of interconnection to the service do you provide? Choose all that apply.'
 dependsOnLots: 'PaaS, IaaS'
 assuranceApproach: 2answers-type1
-fields:
+type: checkboxes
+options:
     -
-        type: checkbox
         label: 'Encrypted PSN service'
         filterLabel: 'Encrypted PSN service'
     -
-        type: checkbox
         label: 'PSN service'
         filterLabel: 'PSN service'
     -
-        type: checkbox
         label: 'Private WAN'
         filterLabel: 'Private WAN'
     -
-        type: checkbox
         label: Internet
         filterLabel: Internet
 validationNotAnswered: 'This question requires an answer.'

--- a/g6/legalJurisdiction.yml
+++ b/g6/legalJurisdiction.yml
@@ -3,25 +3,21 @@ filters: 'The legal jurisdiction(s) in which the service provider operates'
 hint: 'Choose 1'
 dependsOnLots: 'SaaS, PaaS, IaaS'
 assuranceApproach: 3answers-type1
-fields:
+type: radios
+options:
     -
-        type: radio
         label: UK
         filterLabel: UK
     -
-        type: radio
         label: EU
         filterLabel: EU
     -
-        type: radio
         label: 'USA - Safe Harbor'
         filterLabel: 'USA - Safe Harbor'
     -
-        type: radio
         label: 'Other countries with data protection treaties'
         filterLabel: 'Other countries with data protection treaties'
     -
-        type: radio
         label: 'Rest of world'
 validationNotAnswered: 'This question requires an answer.'
 question: 'Legal jurisdiction of service provider'

--- a/g6/managementInterfaceProtection.yml
+++ b/g6/managementInterfaceProtection.yml
@@ -3,9 +3,7 @@ filters: 'The consumer understands how management interfaces are protected (see 
 hint: 'Do you tell consumers what functionality and protection is available for management interfaces?'
 dependsOnLots: 'PaaS, IaaS'
 assuranceApproach: 2answers-type2
-fields:
-    -
-        type: boolean
-        filterLabel: 'Management interface protection'
+type: boolean
+filterLabel: 'Management interface protection'
 validationNotAnswered: 'This question requires an answer.'
 question: 'Management interface protection'

--- a/g6/minimumContractPeriod.yml
+++ b/g6/minimumContractPeriod.yml
@@ -1,23 +1,19 @@
 dependsOnLots: 'SaaS, PaaS, IaaS, SCS'
-fields:
+type: radios
+options:
     -
-        type: radio
         label: Hour
         filterLabel: Hour
     -
-        type: radio
         label: Day
         filterLabel: Day
     -
-        type: radio
         label: Month
         filterLabel: Month
     -
-        type: radio
         label: Year
         filterLabel: Year
     -
-        type: radio
         label: Other
 validationNotAnswered: 'This question requires an answer.'
 question: 'Minimum contract period'

--- a/g6/networksConnected.yml
+++ b/g6/networksConnected.yml
@@ -1,33 +1,27 @@
 dependsOnLots: 'SaaS, PaaS, IaaS'
 mockAnswer: Internet
 hint: 'Choose all that apply.'
-fields:
+type: checkboxes
+options:
     -
-        type: checkbox
         label: Internet
         filterLabel: Internet
     -
-        type: checkbox
         label: 'Public Services Network (PSN)'
         filterLabel: 'Public Services Network (PSN)'
     -
-        type: checkbox
         label: 'Government Secure intranet (GSi)'
         filterLabel: 'Government Secure intranet (GSi)'
     -
-        type: checkbox
         label: 'Police National Network (PNN)'
         filterLabel: 'Police National Network (PNN)'
     -
-        type: checkbox
         label: 'New NHS Network (N3)'
         filterLabel: 'New NHS Network (N3)'
     -
-        type: checkbox
         label: 'Joint Academic Network (JANET)'
         filterLabel: 'Joint Academic Network (JANET)'
     -
-        type: checkbox
         label: Other
 validationNotAnswered: 'This question requires an answer.'
 question: 'Networks the service is directly connected to'

--- a/g6/offlineWorking.yml
+++ b/g6/offlineWorking.yml
@@ -1,7 +1,5 @@
 dependsOnLots: 'SaaS, PaaS, IaaS'
-fields:
-    -
-        type: boolean
-        filterLabel: 'Offline working and syncing supported'
+type: boolean
+filterLabel: 'Offline working and syncing supported'
 validationNotAnswered: 'This question requires an answer.'
 question: 'Offline working and syncing supported'

--- a/g6/onboardingGuidance.yml
+++ b/g6/onboardingGuidance.yml
@@ -3,9 +3,7 @@ filters: 'The consumer understands how to safely connect to the service whilst m
 hint: 'Do you provide onboarding guidance covering secure connection to the service?'
 dependsOnLots: 'PaaS, IaaS'
 assuranceApproach: 2answers-type1
-fields:
-    -
-        type: boolean
-        filterLabel: 'Onboarding guidance provided'
+type: boolean
+filterLabel: 'Onboarding guidance provided'
 validationNotAnswered: 'This question requires an answer.'
 question: 'Onboarding guidance provided'

--- a/g6/openSource.yml
+++ b/g6/openSource.yml
@@ -1,7 +1,5 @@
 dependsOnLots: 'SaaS, PaaS, IaaS'
-fields:
-    -
-        type: boolean
-        filterLabel: 'Open-source software used and supported'
+type: boolean
+filterLabel: 'Open-source software used and supported'
 validationNotAnswered: 'This question requires an answer.'
 question: 'Open-source software used and supported'

--- a/g6/openStandardsSupported.yml
+++ b/g6/openStandardsSupported.yml
@@ -1,8 +1,6 @@
 dependsOnLots: 'SaaS, PaaS, IaaS'
 hint: 'Take a look at the GOV.UK Open Standards principles for more information on open standards.'
-fields:
-    -
-        type: boolean
-        filterLabel: 'Open standards supported and documented'
+type: boolean
+filterLabel: 'Open standards supported and documented'
 validationNotAnswered: 'This question requires an answer.'
 question: 'Open standards supported and documented'

--- a/g6/otherConsumers.yml
+++ b/g6/otherConsumers.yml
@@ -3,21 +3,18 @@ filters: 'Consumers should understand the types of consumer they share the servi
 hint: 'What types of other consumer do you share the service or platform with?'
 dependsOnLots: 'SaaS, PaaS, IaaS'
 assuranceApproach: 3answers-type1
-fields:
+type: radios
+options:
     -
-        type: radio
         label: 'No other consumer'
         filterLabel: 'No other consumer'
     -
-        type: radio
         label: 'Only government consumers'
         filterLabel: 'Only government consumers'
     -
-        type: radio
         label: 'A specific consumer group, eg Police, Defence or Health'
         filterLabel: 'A specific consumer group, eg Police, Defence or Health'
     -
-        type: radio
         label: 'Anyone - public'
 validationNotAnswered: 'This question requires an answer.'
 question: 'Type of consumer'

--- a/g6/persistantStorage.yml
+++ b/g6/persistantStorage.yml
@@ -1,7 +1,5 @@
 dependsOnLots: 'SaaS, PaaS, IaaS'
-fields:
-    -
-        type: boolean
-        filterLabel: 'Persistent storage supported'
+type: boolean
+filterLabel: 'Persistent storage supported'
 validationNotAnswered: 'This question requires an answer.'
 question: 'Persistent storage supported'

--- a/g6/personnelSecurityChecks.yml
+++ b/g6/personnelSecurityChecks.yml
@@ -3,21 +3,18 @@ filters: 'Consumers should be content with the level of security screening condu
 hint: 'What kind of personnel security do you apply to staff who have access to the service? Choose all that apply.'
 dependsOnLots: 'SaaS, PaaS, IaaS'
 assuranceApproach: 2answers-type1
-fields:
+type: checkboxes
+options:
     -
-        type: checkbox
         label: 'Security clearance national vetting (SC)'
         filterLabel: 'Security clearance national vetting (SC)'
     -
-        type: checkbox
         label: 'Baseline personnel security standard (BPSS)'
         filterLabel: 'Baseline personnel security standard (BPSS)'
     -
-        type: checkbox
         label: 'Background checks in accordance with BS7858:2012'
         filterLabel: 'Background checks in accordance with BS7858:2012'
     -
-        type: checkbox
         label: 'Employment checks'
         filterLabel: 'Employment checks'
 validationNotAnswered: 'This question requires an answer.'

--- a/g6/provisioningTime.yml
+++ b/g6/provisioningTime.yml
@@ -1,7 +1,5 @@
 dependsOnLots: 'SaaS, PaaS, IaaS'
 hint: 'How long does it take to get your service up and running? For example 1 to 5 hours, 2 to 3 days.'
-fields:
-    -
-        type: text
+type: text
 validationNotAnswered: 'This question requires an answer.'
 question: 'Service provisioning time'

--- a/g6/restrictAdministratorPermissions.yml
+++ b/g6/restrictAdministratorPermissions.yml
@@ -3,9 +3,7 @@ filters: 'The consumer can manage the risks of their own privileged access, e.g.
 hint: 'Can consumers restrict permissions given to their administrators?'
 dependsOnLots: 'SaaS, PaaS, IaaS'
 assuranceApproach: 2answers-type2
-fields:
-    -
-        type: boolean
-        filterLabel: 'Administrator permissions'
+type: boolean
+filterLabel: 'Administrator permissions'
 validationNotAnswered: 'This question requires an answer.'
 question: 'Administrator permissions'

--- a/g6/secureConfigurationManagement.yml
+++ b/g6/secureConfigurationManagement.yml
@@ -3,9 +3,7 @@ filters: 'Consumers should be sufficiently confident that configuration manageme
 hint: 'Do you have configuration management in place to ensure the integrity of the service through development, testing and deployment?'
 dependsOnLots: 'SaaS, PaaS, IaaS'
 assuranceApproach: 2answers-type1
-fields:
-    -
-        type: boolean
-        filterLabel: 'Software configuration management'
+type: boolean
+filterLabel: 'Software configuration management'
 validationNotAnswered: 'This question requires an answer.'
 question: 'Software configuration management'

--- a/g6/secureDesign.yml
+++ b/g6/secureDesign.yml
@@ -3,9 +3,7 @@ filters: 'Consumers should be sufficiently confident that development is carried
 hint: 'Is development carried out in line with industry good practice regarding secure design, coding, testing and deployment?'
 dependsOnLots: 'SaaS, PaaS, IaaS'
 assuranceApproach: 2answers-type1
-fields:
-    -
-        type: boolean
-        filterLabel: 'Secure design, coding, testing and deployment'
+type: boolean
+filterLabel: 'Secure design, coding, testing and deployment'
 validationNotAnswered: 'This question requires an answer.'
 question: 'Secure design, coding, testing and deployment'

--- a/g6/secureDevelopment.yml
+++ b/g6/secureDevelopment.yml
@@ -3,9 +3,7 @@ filters: 'Consumers should be sufficiently confident that new and evolving threa
 hint: 'Are new and evolving threats reviewed and your services improved accordingly?'
 dependsOnLots: 'SaaS, PaaS, IaaS'
 assuranceApproach: 2answers-type1
-fields:
-    -
-        type: boolean
-        filterLabel: 'Secure development'
+type: boolean
+filterLabel: 'Secure development'
 validationNotAnswered: 'This question requires an answer.'
 question: 'Secure development'

--- a/g6/selfServiceProvisioning.yml
+++ b/g6/selfServiceProvisioning.yml
@@ -1,7 +1,5 @@
 dependsOnLots: 'SaaS, PaaS, IaaS'
-fields:
-    -
-        type: boolean
-        filterLabel: 'Self-service provisioning supported'
+type: boolean
+filterLabel: 'Self-service provisioning supported'
 validationNotAnswered: 'This question requires an answer.'
 question: 'Self-service provisioning supported'

--- a/g6/serviceAvailabilityPercentage.yml
+++ b/g6/serviceAvailabilityPercentage.yml
@@ -3,10 +3,8 @@ filters: 'Consumers should be sufficiently confident that the availability commi
 hint: 'What is the availability of the service? eg 99.99'
 dependsOnLots: 'SaaS, PaaS, IaaS'
 assuranceApproach: 3answers-type1
-fields:
-    -
-        type: percentage
-        filterLabel: 'Service availability'
+type: percentage
+filterLabel: 'Service availability'
 validationNotAnswered: 'This question requires an answer.'
 validationNotANumber: 'Availability must be a number less than 100'
 question: 'Service availability'

--- a/g6/serviceBenefits.yml
+++ b/g6/serviceBenefits.yml
@@ -2,9 +2,7 @@ hint: 'Include benefits that show how your service helps users improve their bus
 mockAnswer: 'Publish content, Quickly manage content on the move'
 dependsOnLots: 'SaaS, PaaS, IaaS, SCS'
 listItemName: 'service benefit'
-fields:
-    -
-        type: list
-        addthing: 'Add another business benefit'
+type: list
+addthing: 'Add another business benefit'
 validationNotAnswered: 'This question requires an answer.'
 question: 'Service benefits'

--- a/g6/serviceConfigurationGuidance.yml
+++ b/g6/serviceConfigurationGuidance.yml
@@ -3,9 +3,7 @@ filters: 'The consumer understands the security requirements on their processes,
 hint: 'Do you provide guidance on service configuration options and the relative impacts on security?'
 dependsOnLots: 'PaaS, IaaS'
 assuranceApproach: 3answers-type2
-fields:
-    -
-        type: boolean
-        filterLabel: 'Service configuration guidance'
+type: boolean
+filterLabel: 'Service configuration guidance'
 validationNotAnswered: 'This question requires an answer.'
 question: 'Service configuration guidance'

--- a/g6/serviceFeatures.yml
+++ b/g6/serviceFeatures.yml
@@ -2,9 +2,7 @@ hint: 'Include the technical features of your product, eg graphical workflow, re
 mockAnswer: 'Graphical workflow, Remote access, Revision control'
 dependsOnLots: 'SaaS, PaaS, IaaS, SCS'
 listItemName: 'service feature'
-fields:
-    -
-        type: list
-        addthing: 'Add another feature'
+type: list
+addthing: 'Add another feature'
 validationNotAnswered: 'This question requires an answer.'
 question: 'Service features'

--- a/g6/serviceManagementModel.yml
+++ b/g6/serviceManagementModel.yml
@@ -3,25 +3,21 @@ filters: 'Consumers have sufficient confidence that the technical approach the s
 hint: 'Which technical approach do you use for your service management? Choose 1.'
 dependsOnLots: 'SaaS, PaaS, IaaS'
 assuranceApproach: 2answers-type1
-fields:
+type: radios
+options:
     -
-        type: radio
         label: 'Dedicated devices on a segregated network'
         filterLabel: 'Dedicated devices on a segregated network'
     -
-        type: radio
         label: 'Dedicated devices for community service management'
         filterLabel: 'Dedicated devices for community service management'
     -
-        type: radio
         label: 'Dedicated devices for multiple community service management'
         filterLabel: 'Dedicated devices for multiple community service management'
     -
-        type: radio
         label: 'Service management via bastion hosts'
         filterLabel: 'Service management via bastion hosts'
     -
-        type: radio
         label: 'Direct service management'
         filterLabel: 'Direct service management'
 validationNotAnswered: 'This question requires an answer.'

--- a/g6/serviceName.yml
+++ b/g6/serviceName.yml
@@ -1,8 +1,6 @@
 hint: 'Include your product name only. Using additional keywords may impact your acceptance on to the Digital Marketplace.'
 mockAnswer: 'Umbraco CMS'
 dependsOnLots: 'SaaS, PaaS, IaaS, SCS'
-fields:
-    -
-        type: text
+type: text
 validationNotAnswered: 'This question requires an answer.'
 question: 'Service name'

--- a/g6/serviceOffboarding.yml
+++ b/g6/serviceOffboarding.yml
@@ -1,7 +1,5 @@
 dependsOnLots: 'SaaS, PaaS, IaaS'
-fields:
-    -
-        type: boolean
-        filterLabel: 'Service offboarding process included'
+type: boolean
+filterLabel: 'Service offboarding process included'
 validationNotAnswered: 'This question requires an answer.'
 question: 'Service offboarding process included'

--- a/g6/serviceOnboarding.yml
+++ b/g6/serviceOnboarding.yml
@@ -1,7 +1,5 @@
 dependsOnLots: 'SaaS, PaaS, IaaS'
-fields:
-    -
-        type: boolean
-        filterLabel: 'Service onboarding process included'
+type: boolean
+filterLabel: 'Service onboarding process included'
 validationNotAnswered: 'This question requires an answer.'
 question: 'Service onboarding process included'

--- a/g6/servicePrice.yml
+++ b/g6/servicePrice.yml
@@ -4,7 +4,5 @@ validationNoMinPriceSpecified: 'Minimum price requires an answer.'
 validationNoUnitSpecified: 'Pricing unit requires an answer. If none of the provided units apply, please choose ''Unit''.'
 validationNotANumber: 'Prices must be numbers only, without units, eg 99.95'
 validationMaxLessThanMin: 'Minimum price must be less than maximum price'
-fields:
-    -
-        type: pricing
+type: pricing
 question: 'Service price'

--- a/g6/serviceSummary.yml
+++ b/g6/serviceSummary.yml
@@ -1,10 +1,8 @@
 hint: 'Please provide a short description of your service. (Maximum 50 words.) You''ll be asked to go into more detail about the features and benefits of your service on the next page. Company information should not be included here. You can provide a company description for your supplier page elsewhere.'
 mockAnswer: 'Professional website development to enhance the delivery and performance of online services based on Sitecore or Umbraco Content Management Systems. We provide development and support services for large scale, business critical websites for many organisations including NHS Direct, Department for Education and the Department for Business, Innovation and Skills.'
 dependsOnLots: 'SaaS, PaaS, IaaS, SCS'
-fields:
-    -
-        type: textarea
-        maxLengthInWords: 50
+type: textarea
+maxLengthInWords: 50
 validationNotAnswered: 'This question requires an answer.'
 question: 'Service summary'
 type: textbox_large

--- a/g6/serviceTypes.yml
+++ b/g6/serviceTypes.yml
@@ -1,25 +1,21 @@
 dependsOnLots: SCS
 hint: 'You can choose multiple categories'
 mockAnswer: 'Content management system'
-fields:
+type: checkboxes
+options:
     -
-        type: checkbox
         label: Implementation
         filterLabel: Implementation
     -
-        type: checkbox
         label: 'Ongoing support'
         filterLabel: 'Ongoing support'
     -
-        type: checkbox
         label: Planning
         filterLabel: Planning
     -
-        type: checkbox
         label: Testing
         filterLabel: Testing
     -
-        type: checkbox
         label: Training
         filterLabel: Training
 validationNotAnswered: 'This question requires an answer.'

--- a/g6/servicesManagementSepartion.yml
+++ b/g6/servicesManagementSepartion.yml
@@ -3,9 +3,7 @@ filters: 'Consumers should have confidence that their management of the service 
 hint: 'Is your management of a consumer’s service kept separate from other consumers?'
 dependsOnLots: 'SaaS, PaaS, IaaS'
 assuranceApproach: 4answers-type3
-fields:
-    -
-        type: boolean
-        filterLabel: 'Services management separation'
+type: boolean
+filterLabel: 'Services management separation'
 validationNotAnswered: 'This question requires an answer.'
 question: 'Services management separation'

--- a/g6/servicesSeparation.yml
+++ b/g6/servicesSeparation.yml
@@ -3,9 +3,7 @@ filters: 'Consumers should have confidence that the service provides sufficient 
 hint: 'Do you securely separate consumer data and services from other consumers of the service?'
 dependsOnLots: 'SaaS, PaaS, IaaS'
 assuranceApproach: 4answers-type3
-fields:
-    -
-        type: boolean
-        filterLabel: 'Services separation'
+type: boolean
+filterLabel: 'Services separation'
 validationNotAnswered: 'This question requires an answer.'
 question: 'Services separation'

--- a/g6/supportAvailability.yml
+++ b/g6/supportAvailability.yml
@@ -1,7 +1,5 @@
 dependsOnLots: 'SaaS, PaaS, IaaS, SCS'
 hint: 'eg 24/7 or 9 to 5. (Maximum 20 words.)'
-fields:
-    -
-        type: text
+type: text
 validationNotAnswered: 'This question requires an answer.'
 question: 'Support availablility'

--- a/g6/supportForThirdParties.yml
+++ b/g6/supportForThirdParties.yml
@@ -1,7 +1,5 @@
 dependsOnLots: 'SaaS, PaaS, IaaS, SCS'
-fields:
-    -
-        type: boolean
-        filterLabel: 'Support accessible to any third-party suppliers'
+type: boolean
+filterLabel: 'Support accessible to any third-party suppliers'
 validationNotAnswered: 'This question requires an answer.'
 question: 'Support accessible to any third-party suppliers'

--- a/g6/supportResponseTime.yml
+++ b/g6/supportResponseTime.yml
@@ -1,7 +1,5 @@
 dependsOnLots: 'SaaS, PaaS, IaaS, SCS'
 hint: 'How long will it take until support can begin to be provided? eg 1 hour or 1 business day. (Maximum 20 words.)'
-fields:
-    -
-        type: text
+type: text
 validationNotAnswered: 'This question requires an answer.'
 question: 'Standard support response times'

--- a/g6/supportTypes.yml
+++ b/g6/supportTypes.yml
@@ -1,24 +1,20 @@
 dependsOnLots: 'SaaS, PaaS, IaaS, SCS'
 hint: 'Choose all that apply.'
-fields:
+type: checkboxes
+options:
     -
-        type: checkbox
         label: 'Service desk'
         filterLabel: 'Service desk'
     -
-        type: checkbox
         label: Email
         filterLabel: Email
     -
-        type: checkbox
         label: Phone
         filterLabel: Phone
     -
-        type: checkbox
         label: 'Live chat'
         filterLabel: 'Live chat'
     -
-        type: checkbox
         label: Onsite
         filterLabel: Onsite
 validationNotAnswered: 'This question requires an answer.'

--- a/g6/supportedBrowsers.yml
+++ b/g6/supportedBrowsers.yml
@@ -1,40 +1,32 @@
 dependsOnLots: 'SaaS, PaaS, IaaS'
 hint: 'Choose all that apply.'
-fields:
+type: checkboxes
+options:
     -
-        type: checkbox
         label: 'Internet Explorer 6'
         filterLabel: 'Internet Explorer 6'
     -
-        type: checkbox
         label: 'Internet Explorer 7'
         filterLabel: 'Internet Explorer 7'
     -
-        type: checkbox
         label: 'Internet Explorer 8'
         filterLabel: 'Internet Explorer 8'
     -
-        type: checkbox
         label: 'Internet Explorer 9'
         filterLabel: 'Internet Explorer 9'
     -
-        type: checkbox
         label: 'Internet Explorer 10+'
         filterLabel: 'Internet Explorer 10+'
     -
-        type: checkbox
         label: Firefox
         filterLabel: Firefox
     -
-        type: checkbox
         label: Chrome
         filterLabel: Chrome
     -
-        type: checkbox
         label: Safari
         filterLabel: Safari
     -
-        type: checkbox
         label: Opera
         filterLabel: Opera
 validationNotAnswered: 'This question requires an answer.'

--- a/g6/supportedDevices.yml
+++ b/g6/supportedDevices.yml
@@ -1,20 +1,17 @@
 dependsOnLots: 'SaaS, PaaS, IaaS'
 hint: 'Choose all that apply.'
-fields:
+type: checkboxes
+options:
     -
-        type: checkbox
         label: PC
         filterLabel: PC
     -
-        type: checkbox
         label: Mac
         filterLabel: Mac
     -
-        type: checkbox
         label: Smartphone
         filterLabel: Smartphone
     -
-        type: checkbox
         label: Tablet
         filterLabel: Tablet
 validationNotAnswered: 'This question requires an answer.'

--- a/g6/terminationCost.yml
+++ b/g6/terminationCost.yml
@@ -1,7 +1,5 @@
 dependsOnLots: 'PaaS, IaaS, SCS'
-fields:
-    -
-        type: boolean
-        filterLabel: 'Termination cost'
+type: boolean
+filterLabel: 'Termination cost'
 validationNotAnswered: 'This question requires an answer.'
 question: 'Termination cost'

--- a/g6/thirdPartyComplianceMonitoring.yml
+++ b/g6/thirdPartyComplianceMonitoring.yml
@@ -3,9 +3,7 @@ filters: 'The consumer understands and accepts how the service provider manages 
 hint: 'Do you manage your third-party suppliers'' compliance with relevant security requirements?'
 dependsOnLots: 'SaaS, PaaS, IaaS'
 assuranceApproach: 2answers-type1
-fields:
-    -
-        type: boolean
-        filterLabel: 'Third-party supplier compliance monitoring'
+type: boolean
+filterLabel: 'Third-party supplier compliance monitoring'
 validationNotAnswered: 'This question requires an answer.'
 question: 'Third-party supplier compliance monitoring'

--- a/g6/thirdPartyDataSharingInformation.yml
+++ b/g6/thirdPartyDataSharingInformation.yml
@@ -3,9 +3,7 @@ filters: 'The consumer understands and accepts how their information is shared w
 hint: 'Do you inform consumers how much of their information is shared with, or accessible by, third-party suppliers and their supply chains?'
 dependsOnLots: 'SaaS, PaaS, IaaS'
 assuranceApproach: 2answers-type1
-fields:
-    -
-        type: boolean
-        filterLabel: 'Visibility of data shared with third-party suppliers'
+type: boolean
+filterLabel: 'Visibility of data shared with third-party suppliers'
 validationNotAnswered: 'This question requires an answer.'
 question: 'Visibility of data shared with third-party suppliers'

--- a/g6/thirdPartyRiskAssessment.yml
+++ b/g6/thirdPartyRiskAssessment.yml
@@ -3,9 +3,7 @@ filters: 'The consumer understands and accepts how the service provider manages 
 hint: 'Do you manage the risks to your service from third-party suppliers and delivery partners?'
 dependsOnLots: 'SaaS, PaaS, IaaS'
 assuranceApproach: 2answers-type1
-fields:
-    -
-        type: boolean
-        filterLabel: 'Third-party supplier risk assessment'
+type: boolean
+filterLabel: 'Third-party supplier risk assessment'
 validationNotAnswered: 'This question requires an answer.'
 question: 'Third-party supplier risk assessment'

--- a/g6/thirdPartySecurityRequirements.yml
+++ b/g6/thirdPartySecurityRequirements.yml
@@ -3,9 +3,7 @@ filters: 'The consumer understands and accepts how the service provider’s proc
 hint: 'Do you ensure that relevant security requirements, such as the Cloud Security Principles, are placed on third-party suppliers and delivery partners?'
 dependsOnLots: 'SaaS, PaaS, IaaS'
 assuranceApproach: 2answers-type1
-fields:
-    -
-        type: boolean
-        filterLabel: 'Third-party supplier security requirements'
+type: boolean
+filterLabel: 'Third-party supplier security requirements'
 validationNotAnswered: 'This question requires an answer.'
 question: 'Third-party supplier security requirements'

--- a/g6/trainingProvided.yml
+++ b/g6/trainingProvided.yml
@@ -3,9 +3,7 @@ filters: 'The consumer can educate those administrating and using the service in
 hint: 'Do you provide user or administrator training on the use of the service and its security?'
 dependsOnLots: 'SaaS, PaaS, IaaS'
 assuranceApproach: 2answers-type1
-fields:
-    -
-        type: boolean
-        filterLabel: Training
+type: boolean
+filterLabel: Training
 validationNotAnswered: 'This question requires an answer.'
 question: Training

--- a/g6/trialOption.yml
+++ b/g6/trialOption.yml
@@ -1,7 +1,5 @@
 dependsOnLots: 'SaaS, PaaS, IaaS'
-fields:
-    -
-        type: boolean
-        filterLabel: 'Trial option'
+type: boolean
+filterLabel: 'Trial option'
 validationNotAnswered: 'This question requires an answer.'
 question: 'Trial option'

--- a/g6/undefined.yml
+++ b/g6/undefined.yml
@@ -2,93 +2,72 @@ id: serviceTypes
 dependsOnLots: SaaS
 hint: 'You can choose multiple categories'
 mockAnswer: 'Content management system'
-fields:
+type: checkboxes
+options:
     -
-        type: checkbox
         label: 'Accounting and finance'
         filterLabel: 'Accounting and finance'
     -
-        type: checkbox
         label: 'Business intelligence and analytics'
         filterLabel: 'Business intelligence and analytics'
     -
-        type: checkbox
         label: Collaboration
         filterLabel: Collaboration
     -
-        type: checkbox
         label: 'Creative and design'
         filterLabel: 'Creative and design'
     -
-        type: checkbox
         label: 'Customer relationship management (CRM)'
         filterLabel: 'Customer relationship management (CRM)'
     -
-        type: checkbox
         label: 'Data management'
         filterLabel: 'Data management'
     -
-        type: checkbox
         label: 'Electronic document and records management (EDRM)'
         filterLabel: 'Electronic document and records management (EDRM)'
     -
-        type: checkbox
         label: 'Energy and environment'
         filterLabel: 'Energy and environment'
     -
-        type: checkbox
         label: Healthcare
         filterLabel: Healthcare
     -
-        type: checkbox
         label: 'Human resources and employee management'
         filterLabel: 'Human resources and employee management'
     -
-        type: checkbox
         label: 'IT management'
         filterLabel: 'IT management'
     -
-        type: checkbox
         label: Legal
         filterLabel: Legal
     -
-        type: checkbox
         label: Libraries
         filterLabel: Libraries
     -
-        type: checkbox
         label: Marketing
         filterLabel: Marketing
     -
-        type: checkbox
         label: 'Operations management'
         filterLabel: 'Operations management'
     -
-        type: checkbox
         label: 'Project management and planning'
         filterLabel: 'Project management and planning'
     -
-        type: checkbox
         label: Sales
         filterLabel: Sales
     -
-        type: checkbox
         label: 'Schools and education'
         filterLabel: 'Schools and education'
     -
-        type: checkbox
         label: Security
         filterLabel: Security
     -
-        type: checkbox
         label: 'Software development tools'
         filterLabel: 'Software development tools'
     -
-        type: checkbox
         label: Telecoms
         filterLabel: Telecoms
     -
-        type: checkbox
         label: 'Transport and logistics'
         filterLabel: 'Transport and logistics'
 validationNotAnswered: 'This question requires an answer.'

--- a/g6/userAccessControlManagement.yml
+++ b/g6/userAccessControlManagement.yml
@@ -3,9 +3,7 @@ filters: 'The consumer has sufficient confidence that other consumers cannot acc
 hint: 'Can consumers manage only their own service, and not access, modify or otherwise affect the service of other consumers via management tools and interfaces?'
 dependsOnLots: 'SaaS, PaaS, IaaS'
 assuranceApproach: 2answers-type2
-fields:
-    -
-        type: boolean
-        filterLabel: 'User access control within management interfaces'
+type: boolean
+filterLabel: 'User access control within management interfaces'
 validationNotAnswered: 'This question requires an answer.'
 question: 'User access control within management interfaces'

--- a/g6/userAuthenticateManagement.yml
+++ b/g6/userAuthenticateManagement.yml
@@ -3,9 +3,7 @@ filters: 'The consumer has sufficient confidence that only authorised individual
 hint: 'Can only authorised individuals from the consumer organisation access management interfaces for the service?'
 dependsOnLots: 'SaaS, PaaS, IaaS'
 assuranceApproach: 2answers-type2
-fields:
-    -
-        type: boolean
-        filterLabel: 'User authentication and access management'
+type: boolean
+filterLabel: 'User authentication and access management'
 validationNotAnswered: 'This question requires an answer.'
 question: 'User authentication and access management'

--- a/g6/userAuthenticateSupport.yml
+++ b/g6/userAuthenticateSupport.yml
@@ -3,9 +3,7 @@ filters: 'The consumer has sufficient confidence that only authorised individual
 hint: 'Can only authorised individuals from the consumer organisation perform actions affecting the consumer’s service through your support channels?'
 dependsOnLots: 'SaaS, PaaS, IaaS'
 assuranceApproach: 2answers-type2
-fields:
-    -
-        type: boolean
-        filterLabel: 'User access control through support channels'
+type: boolean
+filterLabel: 'User access control through support channels'
 validationNotAnswered: 'This question requires an answer.'
 question: 'User access control through support channels'

--- a/g6/vatIncluded.yml
+++ b/g6/vatIncluded.yml
@@ -1,7 +1,5 @@
 dependsOnLots: 'SaaS, PaaS, IaaS, SCS'
-fields:
-    -
-        type: boolean
-        filterLabel: 'VAT included'
+type: boolean
+filterLabel: 'VAT included'
 validationNotAnswered: 'This question requires an answer.'
 question: 'VAT included'

--- a/g6/vendorCertifications.yml
+++ b/g6/vendorCertifications.yml
@@ -1,8 +1,6 @@
 dependsOnLots: 'SaaS, PaaS, IaaS, SCS'
 hint: 'Examples of certifications include VMware Certified Professional and Oracle Gold Partner. (Optional.)'
 listItemName: 'certification example'
-fields:
-    -
-        type: list
-        addthing: 'Add another certification'
+type: list
+addthing: 'Add another certification'
 question: 'Vendor certification(s)'

--- a/g6/vulnerabilityAssessment.yml
+++ b/g6/vulnerabilityAssessment.yml
@@ -3,9 +3,7 @@ filters: 'Consumers should have confidence that potential new threats, vulnerabi
 hint: 'Are potential threats, vulnerabilities or exploitation techniques which could affect the service assessed, and are corrective actions taken?'
 dependsOnLots: 'SaaS, PaaS, IaaS'
 assuranceApproach: 2answers-type1
-fields:
-    -
-        type: boolean
-        filterLabel: 'Vulnerability assessment'
+type: boolean
+filterLabel: 'Vulnerability assessment'
 validationNotAnswered: 'This question requires an answer.'
 question: 'Vulnerability assessment'

--- a/g6/vulnerabilityMitigationPrioritisation.yml
+++ b/g6/vulnerabilityMitigationPrioritisation.yml
@@ -3,9 +3,7 @@ filters: 'Consumers should have confidence that the severity of threats and vuln
 hint: 'Is the severity of threats and vulnerabilities considered and do you use this information to prioritise implementation of mitigations?'
 dependsOnLots: 'SaaS, PaaS, IaaS'
 assuranceApproach: 2answers-type1
-fields:
-    -
-        type: boolean
-        filterLabel: 'Vulnerability mitigation prioritisation'
+type: boolean
+filterLabel: 'Vulnerability mitigation prioritisation'
 validationNotAnswered: 'This question requires an answer.'
 question: 'Vulnerability mitigation prioritisation'

--- a/g6/vulnerabilityMonitoring.yml
+++ b/g6/vulnerabilityMonitoring.yml
@@ -3,9 +3,7 @@ filters: 'Consumers should have confidence that relevant sources of information 
 hint: 'Do you monitor relevant sources of information relating to threat, vulnerability and exploitation techniques?'
 dependsOnLots: 'SaaS, PaaS, IaaS'
 assuranceApproach: 2answers-type1
-fields:
-    -
-        type: boolean
-        filterLabel: 'Vulnerability monitoring'
+type: boolean
+filterLabel: 'Vulnerability monitoring'
 validationNotAnswered: 'This question requires an answer.'
 question: 'Vulnerability monitoring'

--- a/g6/vulnerabilityTimescales.yml
+++ b/g6/vulnerabilityTimescales.yml
@@ -3,9 +3,7 @@ filters: 'Consumers should have confidence that service provider timescales for 
 hint: 'Do you make timescales available for implementing mitigations to vulnerabilities?'
 dependsOnLots: 'SaaS, PaaS, IaaS'
 assuranceApproach: 2answers-type1
-fields:
-    -
-        type: boolean
-        filterLabel: 'Vulnerability mitigation timescales'
+type: boolean
+filterLabel: 'Vulnerability mitigation timescales'
 validationNotAnswered: 'This question requires an answer.'
 question: 'Vulnerability mitigation timescales'

--- a/g6/vulnerabilityTracking.yml
+++ b/g6/vulnerabilityTracking.yml
@@ -3,9 +3,7 @@ filters: 'Consumers should have confidence that known vulnerabilities within the
 hint: 'Are known vulnerabilities within the service tracked until suitable mitigations have been deployed?'
 dependsOnLots: 'SaaS, PaaS, IaaS'
 assuranceApproach: 2answers-type1
-fields:
-    -
-        type: boolean
-        filterLabel: 'Vulnerability tracking'
+type: boolean
+filterLabel: 'Vulnerability tracking'
 validationNotAnswered: 'This question requires an answer.'
 question: 'Vulnerability tracking'


### PR DESCRIPTION
This commit does two things:

1. Put the `type` property at the top level, so that each question has a type  (eg `checkboxes`, `textarea`)
2. Rename `fields`, for questions that have multiple options, to `options`

This new format already existed for questions used by the admin app and is now consistent across all questions.