### PR TITLE
Fix ISO27001 typo

### DIFF
--- a/g6/governanceFramework.yml
+++ b/g6/governanceFramework.yml
@@ -1,6 +1,6 @@
 requirements: 'The consumer should have sufficient confidence that the governance framework and processes in place for the service are appropriate for their intended use of it.'
 filters: 'The consumer should have sufficient confidence that the governance framework and processes in place for the service are appropriate for their intended use of it.'
-hint: 'Do you have a governance framework and process in place for the service, eg ISO277001:2013?'
+hint: 'Do you have a governance framework and process in place for the service, eg ISO27001:2013?'
 dependsOnLots: 'SaaS, PaaS, IaaS'
 assuranceApproach: 2answers-type1
 type: boolean


### PR DESCRIPTION
CESG noticed that we had misspelled [ISO27001](http://www.iso.org/iso/home/standards/management-standards/iso27001.htm) as ISO27**7**001. This commit fixes it.