### PR TITLE
Change structure of question dependency

### DIFF
--- a/g6/analyticsAvailable.yml
+++ b/g6/analyticsAvailable.yml
@@ -1,4 +1,10 @@
-dependsOnLots: 'SaaS, PaaS, IaaS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
 type: boolean
 filterLabel: 'Real-time management information available'
 validations:

--- a/g6/apiAccess.yml
+++ b/g6/apiAccess.yml
@@ -1,4 +1,10 @@
-dependsOnLots: 'SaaS, PaaS, IaaS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
 type: boolean
 filterLabel: 'API access available and supported'
 validations:

--- a/g6/apiType.yml
+++ b/g6/apiType.yml
@@ -1,4 +1,10 @@
-dependsOnLots: 'SaaS, PaaS, IaaS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
 hint: 'Examples of API include RESTful and SOAP.'
 type: text
 validations:

--- a/g6/auditInformationProvided.yml
+++ b/g6/auditInformationProvided.yml
@@ -1,7 +1,13 @@
 requirements: 'Consumers are aware of the audit information that will be provided to them, how and when it will be made available to them, the format of the data, and the retention period associated with it.'
 filters: 'Consumers are aware of the audit information that will be provided to them, how and when it will be made available to them, the format of the data, and the retention period associated with it.'
 hint: 'Do you provide audit information to consumers? Choose 1.'
-dependsOnLots: 'SaaS, PaaS, IaaS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
 assuranceApproach: 2answers-type1
 type: radios
 options:

--- a/g6/changeImpactAssessment.yml
+++ b/g6/changeImpactAssessment.yml
@@ -1,7 +1,13 @@
 requirements: 'Consumers should have confidence that changes to the service are assessed for potential security impact. Changes are managed and tracked through to completion.'
 filters: 'Consumers should have confidence that changes to the service are assessed for potential security impact. Changes are managed and tracked through to completion.'
 hint: 'Are changes to the service assessed for potential security impact, and are changes managed and tracked through to completion?'
-dependsOnLots: 'SaaS, PaaS, IaaS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
 assuranceApproach: 2answers-type1
 type: boolean
 filterLabel: 'Change impact assessment'

--- a/g6/cloudDeploymentModel.yml
+++ b/g6/cloudDeploymentModel.yml
@@ -1,7 +1,13 @@
 requirements: 'Service providers must state whether the service is a public, private or community cloud service.'
 filters: 'Service providers must state whether the service is a public, private or community cloud service.'
 hint: 'Is the service a public, private, community or hybrid cloud service?'
-dependsOnLots: 'SaaS, PaaS, IaaS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
 assuranceApproach: 3answers-type1
 type: radios
 options:

--- a/g6/codeLibraryLanguages.yml
+++ b/g6/codeLibraryLanguages.yml
@@ -1,4 +1,7 @@
-dependsOnLots: SaaS
+depends:
+  -
+    on: lot
+    being: SaaS
 hint: 'Examples of code libraries include AWS Ruby SDK and Stripe-Java. Examples of languages include PHP and Python. (Maximum 10 languages.) (Optional.) '
 listItemName: 'code libraries example'
 type: list

--- a/g6/configurationTracking.yml
+++ b/g6/configurationTracking.yml
@@ -1,7 +1,12 @@
 requirements: 'Consumers should have confidence that the status, location and configuration of service components (including hardware and software components) are tracked throughout their lifetime within the service.'
 filters: 'Consumers should have confidence that the status, location and configuration of service components (including hardware and software components) are tracked throughout their lifetime within the service.'
 hint: 'Do you track the status, location and configuration of service components throughout their lifetime?'
-dependsOnLots: 'PaaS, IaaS'
+depends:
+  -
+    on: lot
+    being:
+      - PaaS
+      - IaaS
 assuranceApproach: 2answers-type1
 type: boolean
 filterLabel: 'Configuration and change management tracking'

--- a/g6/dataAtRestProtections.yml
+++ b/g6/dataAtRestProtections.yml
@@ -1,7 +1,13 @@
 requirements: 'Consumers should have sufficient confidence that storage media containing their data is protected from unauthorised access.'
 filters: 'Consumers should have sufficient confidence that storage media containing their data is protected from unauthorised access.'
 hint: 'How is storage media containing consumer data protected from unauthorised physical access? Choose 1.'
-dependsOnLots: 'SaaS, PaaS, IaaS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
 assuranceApproach: 4answers-type1
 type: radios
 options:

--- a/g6/dataBackupRecovery.yml
+++ b/g6/dataBackupRecovery.yml
@@ -1,4 +1,10 @@
-dependsOnLots: 'SaaS, PaaS, IaaS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
 servicePageLabel: 'Backup, disaster recovery and resilience plan in place'
 assuranceApproach: null
 hint: 'You can provide more detail on your disaster recovery plan in your service definition document.'

--- a/g6/dataExtractionRemoval.yml
+++ b/g6/dataExtractionRemoval.yml
@@ -1,4 +1,10 @@
-dependsOnLots: 'SaaS, PaaS, IaaS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
 servicePageLabel: 'Data extraction/removal plan in place'
 assuranceApproach: null
 type: boolean

--- a/g6/dataManagementLocations.yml
+++ b/g6/dataManagementLocations.yml
@@ -1,7 +1,13 @@
 requirements: 'The geographic location(s) where consumer data is stored, processed or managed from (to country level)'
 filters: 'The geographic location(s) where consumer data is stored, processed or managed from (to country level)'
 hint: 'Where are the services managed from? Choose all that apply.'
-dependsOnLots: 'SaaS, PaaS, IaaS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
 assuranceApproach: 3answers-type1
 type: checkboxes
 options:

--- a/g6/dataProtectionBetweenServices.yml
+++ b/g6/dataProtectionBetweenServices.yml
@@ -1,7 +1,12 @@
 requirements: 'Data in transit is protected between the service and other services (eg where APIs are exposed)'
 filters: 'Data in transit is protected between the service and other services (eg where APIs are exposed)'
 hint: 'Choose 1'
-dependsOnLots: 'PaaS, IaaS'
+depends:
+  -
+    on: lot
+    being:
+      - PaaS
+      - IaaS
 assuranceApproach: 4answers-type1
 type: radios
 options:

--- a/g6/dataProtectionBetweenUserAndService.yml
+++ b/g6/dataProtectionBetweenUserAndService.yml
@@ -1,7 +1,13 @@
 requirements: 'Data in transit is protected between the user’s devices and the service'
 filters: 'Data in transit is protected between the user’s devices and the service'
 hint: 'Choose 1'
-dependsOnLots: 'SaaS, PaaS, IaaS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
 assuranceApproach: 4answers-type1
 assuranceHint: 'How can you support the above answer?'
 type: radios

--- a/g6/dataProtectionWithinService.yml
+++ b/g6/dataProtectionWithinService.yml
@@ -1,7 +1,12 @@
 requirements: 'Data in transit is protected internally within the service'
 filters: 'Data in transit is protected internally within the service'
 hint: 'Choose 1'
-dependsOnLots: 'PaaS, IaaS'
+depends:
+  -
+    on: lot
+    being:
+      - PaaS
+      - IaaS
 assuranceApproach: 4answers-type1
 type: radios
 options:

--- a/g6/dataRedundantEquipmentAccountsRevoked.yml
+++ b/g6/dataRedundantEquipmentAccountsRevoked.yml
@@ -1,7 +1,12 @@
 requirements: 'Consumers should be sufficiently confident that accounts or credentials specific to redundant equipment are revoked to reduce their value to an attacker.'
 filters: 'Consumers should be sufficiently confident that accounts or credentials specific to redundant equipment are revoked to reduce their value to an attacker.'
 hint: 'Are accounts or credentials specific to redundant equipment revoked to reduce their value to an attacker?'
-dependsOnLots: 'PaaS, IaaS'
+depends:
+  -
+    on: lot
+    being:
+      - PaaS
+      - IaaS
 assuranceApproach: 3answers-type1
 type: boolean
 filterLabel: 'Redundant equipment accounts revoked'

--- a/g6/dataSecureDeletion.yml
+++ b/g6/dataSecureDeletion.yml
@@ -1,7 +1,13 @@
 requirements: 'Consumers should be sufficiently confident that their data is erased when resources are moved or re-provisioned, when they leave the service or when they request it to be erased.'
 filters: 'Consumers should be sufficiently confident that their data is erased when resources are moved or re-provisioned, when they leave the service or when they request it to be erased.'
 hint: 'How do you erase consumer data when resources are moved or re-provisioned, or when the consumer leaves the service, or when they request it to be erased? Choose 1.'
-dependsOnLots: 'SaaS, PaaS, IaaS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
 assuranceApproach: 4answers-type1
 type: radios
 options:

--- a/g6/dataSecureEquipmentDisposal.yml
+++ b/g6/dataSecureEquipmentDisposal.yml
@@ -1,7 +1,12 @@
 requirements: 'Consumers should be sufficiently confident that all equipment potentially containing consumer data, credentials, or configuration information for the service is identified at the end of its life (or prior to being recycled).'
 filters: 'Consumers should be sufficiently confident that all equipment potentially containing consumer data, credentials, or configuration information for the service is identified at the end of its life (or prior to being recycled).'
 hint: 'Is all equipment potentially containing consumer data, credentials or configuration information identified at the end of its life or prior to being recycled? Choose 1.'
-dependsOnLots: 'PaaS, IaaS'
+depends:
+  -
+    on: lot
+    being:
+      - PaaS
+      - IaaS
 assuranceApproach: 4answers-type2
 type: boolean
 filterLabel: 'Secure equipment disposal'

--- a/g6/dataStorageMediaDisposal.yml
+++ b/g6/dataStorageMediaDisposal.yml
@@ -1,7 +1,12 @@
 requirements: 'Consumers should be sufficiently confident that storage media which has held consumer data is sanitised or securely destroyed at the end of its life'
 filters: 'Consumers should be sufficiently confident that storage media which has held consumer data is sanitised or securely destroyed at the end of its life'
 hint: 'How is storage media containing consumer data sanitised or securely destroyed at the end of its usable lifetime? Choose 1.'
-dependsOnLots: 'PaaS, IaaS'
+depends:
+  -
+    on: lot
+    being:
+      - PaaS
+      - IaaS
 assuranceApproach: 5answers-type1
 type: radios
 options:

--- a/g6/datacentreLocations.yml
+++ b/g6/datacentreLocations.yml
@@ -1,7 +1,13 @@
 requirements: 'The geographic location(s) where consumer data is stored, processed or managed from (to country level)'
 filters: 'The geographic location(s) where consumer data is stored, processed or managed from (to country level)'
 hint: 'Where are the service provider''s datacentres located? Choose all that apply.'
-dependsOnLots: 'SaaS, PaaS, IaaS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
 assuranceApproach: 3answers-type1
 type: checkboxes
 options:

--- a/g6/datacentreProtectionDisclosure.yml
+++ b/g6/datacentreProtectionDisclosure.yml
@@ -1,7 +1,13 @@
 requirements: 'Consumers should be confident that the physical security measures employed by the provider are sufficient for their intended use of the service.'
 filters: 'Consumers should be confident that the physical security measures employed by the provider are sufficient for their intended use of the service.'
 hint: 'Do you tell your consumers what physical security your datacentres have?'
-dependsOnLots: 'SaaS, PaaS, IaaS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
 assuranceApproach: 3answers-type1
 type: boolean
 filterLabel: 'Datacentre protection'

--- a/g6/datacentreTier.yml
+++ b/g6/datacentreTier.yml
@@ -1,5 +1,11 @@
 hint: 'Choose one'
-dependsOnLots: 'SaaS, PaaS, IaaS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
 servicePageLabel: 'Datacentre tier'
 assuranceApproach: null
 type: radios

--- a/g6/datacentresEUCode.yml
+++ b/g6/datacentresEUCode.yml
@@ -1,4 +1,10 @@
-dependsOnLots: 'SaaS, PaaS, IaaS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
 servicePageLabel: 'Datacentres adhere to EU Code of Conduct for Operations'
 assuranceApproach: null
 assuranceHint: null

--- a/g6/datacentresSpecifyLocation.yml
+++ b/g6/datacentresSpecifyLocation.yml
@@ -1,4 +1,10 @@
-dependsOnLots: 'SaaS, PaaS, IaaS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
 servicePageLabel: 'User-defined data location'
 assuranceApproach: null
 type: boolean

--- a/g6/deprovisioningTime.yml
+++ b/g6/deprovisioningTime.yml
@@ -1,4 +1,10 @@
-dependsOnLots: 'SaaS, PaaS, IaaS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
 hint: ""
 type: text
 validations:

--- a/g6/deviceAccessMethod.yml
+++ b/g6/deviceAccessMethod.yml
@@ -1,7 +1,13 @@
 requirements: 'The consumer understands any service configuration options available to them and the security implications of choices they make.'
 filters: 'The consumer understands any service configuration options available to them and the security implications of choices they make.'
 hint: 'Which end device is the cloud service accessible from?'
-dependsOnLots: 'SaaS, PaaS, IaaS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
 assuranceApproach: 2answers-type1
 type: radios
 options:

--- a/g6/educationPricing.yml
+++ b/g6/educationPricing.yml
@@ -1,4 +1,11 @@
-dependsOnLots: 'SaaS, PaaS, IaaS, SCS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+      - SCS
 hint: 'Do you offer special pricing for educational organisations?'
 type: boolean
 filterLabel: 'Education pricing'

--- a/g6/elasticCloud.yml
+++ b/g6/elasticCloud.yml
@@ -1,4 +1,10 @@
-dependsOnLots: 'SaaS, PaaS, IaaS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
 type: boolean
 filterLabel: 'Elastic cloud approach supported'
 validations:

--- a/g6/eventMonitoring.yml
+++ b/g6/eventMonitoring.yml
@@ -1,7 +1,13 @@
 requirements: 'Consumers should have confidence that events generated in service components required to support effective identification of suspicious activity are collected and fed into an analysis system.'
 filters: 'Consumers should have confidence that events generated in service components required to support effective identification of suspicious activity are collected and fed into an analysis system.'
 hint: 'Do you conduct event monitoring and analysis to identify suspicious activity?'
-dependsOnLots: 'SaaS, PaaS, IaaS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
 assuranceApproach: 2answers-type1
 type: boolean
 filterLabel: 'Event monitoring'

--- a/g6/freeOption.yml
+++ b/g6/freeOption.yml
@@ -1,4 +1,10 @@
-dependsOnLots: 'SaaS, PaaS, IaaS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
 type: boolean
 filterLabel: 'Free option'
 validations:

--- a/g6/governanceFramework.yml
+++ b/g6/governanceFramework.yml
@@ -1,7 +1,13 @@
 requirements: 'The consumer should have sufficient confidence that the governance framework and processes in place for the service are appropriate for their intended use of it.'
 filters: 'The consumer should have sufficient confidence that the governance framework and processes in place for the service are appropriate for their intended use of it.'
 hint: 'Do you have a governance framework and process in place for the service, eg ISO27001:2013?'
-dependsOnLots: 'SaaS, PaaS, IaaS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
 assuranceApproach: 2answers-type1
 type: boolean
 filterLabel: 'Governance framework'

--- a/g6/guaranteedResources.yml
+++ b/g6/guaranteedResources.yml
@@ -1,4 +1,10 @@
-dependsOnLots: 'SaaS, PaaS, IaaS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
 type: boolean
 filterLabel: 'Guaranteed resources defined'
 validations:

--- a/g6/hardwareSoftwareVerification.yml
+++ b/g6/hardwareSoftwareVerification.yml
@@ -1,7 +1,12 @@
 requirements: 'The consumer understands and accepts how the service provider verifies that hardware and software used in the service is genuine and has not been tampered with.'
 filters: 'The consumer understands and accepts how the service provider verifies that hardware and software used in the service is genuine and has not been tampered with.'
 hint: 'Do you verify that the hardware and software used in the service are genuine and have not been obviously tampered with?'
-dependsOnLots: 'PaaS, IaaS'
+depends:
+  -
+    on: lot
+    being:
+      - PaaS
+      - IaaS
 assuranceApproach: 2answers-type1
 type: boolean
 filterLabel: 'Hardware and software verification'

--- a/g6/identityAuthenticationControls.yml
+++ b/g6/identityAuthenticationControls.yml
@@ -1,7 +1,13 @@
 requirements: 'Consumers should have sufficient confidence that identity and authentication controls ensure users are authorised to access specific interfaces.'
 filters: 'Consumers should have sufficient confidence that identity and authentication controls ensure users are authorised to access specific interfaces.'
 hint: 'How do your identity and authentication controls ensure that users are authorised to access specific interfaces? Choose all that apply.'
-dependsOnLots: 'SaaS, PaaS, IaaS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
 assuranceApproach: 3answers-type3
 type: checkboxes
 options:

--- a/g6/identityStandards.yml
+++ b/g6/identityStandards.yml
@@ -1,4 +1,7 @@
-dependsOnLots: SaaS
+depends:
+  -
+    on: lot
+    being: SaaS
 hint: 'Examples of identity standards include OAuth and SAML. (Optional.)'
 listItemName: 'identity standards example'
 type: list

--- a/g6/incidentDefinitionPublished.yml
+++ b/g6/incidentDefinitionPublished.yml
@@ -1,6 +1,12 @@
 requirements: 'Consumers should have confidence that a defined process and contact route exists for reporting of security incidents by consumers and external entities.'
 filters: 'Consumers should have confidence that a defined process and contact route exists for reporting of security incidents by consumers and external entities.'
-dependsOnLots: 'SaaS, PaaS, IaaS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
 assuranceApproach: 2answers-type1
 hint: 'Do you publish to consumers your definition of a security incident, along with the format, incident triggers and timescales for reporting such incidents?'
 type: boolean

--- a/g6/incidentEscalation.yml
+++ b/g6/incidentEscalation.yml
@@ -1,4 +1,11 @@
-dependsOnLots: 'SaaS, PaaS, IaaS, SCS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+      - SCS
 type: boolean
 filterLabel: 'Incident escalation process available'
 validations:

--- a/g6/incidentManagementProcess.yml
+++ b/g6/incidentManagementProcess.yml
@@ -1,7 +1,13 @@
 requirements: 'Consumers should have confidence that incident management processes are in place for the service and are enacted in response to security incidents.'
 filters: 'Consumers should have confidence that incident management processes are in place for the service and are enacted in response to security incidents.'
 hint: 'Do you have incident management processes in place and are they enacted in response to security incidents?'
-dependsOnLots: 'SaaS, PaaS, IaaS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
 assuranceApproach: 2answers-type1
 type: boolean
 filterLabel: 'Incident management processes'

--- a/g6/incidentManagementReporting.yml
+++ b/g6/incidentManagementReporting.yml
@@ -1,7 +1,13 @@
 requirements: 'Consumers should have confidence that pre-defined processes are in place for responding to common types of incident and attack.'
 filters: 'Consumers should have confidence that pre-defined processes are in place for responding to common types of incident and attack.'
 hint: 'Do you have a defined process for reporting security incidents experienced by consumers and external entities?'
-dependsOnLots: 'SaaS, PaaS, IaaS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
 assuranceApproach: 2answers-type1
 type: boolean
 filterLabel: 'Consumer reporting of security incidents'

--- a/g6/interconnectionMethods.yml
+++ b/g6/interconnectionMethods.yml
@@ -1,7 +1,12 @@
 requirements: 'The consumer understands what physical and logical interfaces their information is available from.'
 filters: 'The consumer understands what physical and logical interfaces their information is available from.'
 hint: 'What method of interconnection to the service do you provide? Choose all that apply.'
-dependsOnLots: 'PaaS, IaaS'
+depends:
+  -
+    on: lot
+    being:
+      - PaaS
+      - IaaS
 assuranceApproach: 2answers-type1
 type: checkboxes
 options:

--- a/g6/legalJurisdiction.yml
+++ b/g6/legalJurisdiction.yml
@@ -1,7 +1,13 @@
 requirements: 'The legal jurisdiction(s) in which the service provider operates'
 filters: 'The legal jurisdiction(s) in which the service provider operates'
 hint: 'Choose 1'
-dependsOnLots: 'SaaS, PaaS, IaaS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
 assuranceApproach: 3answers-type1
 type: radios
 options:

--- a/g6/managementInterfaceProtection.yml
+++ b/g6/managementInterfaceProtection.yml
@@ -1,7 +1,12 @@
 requirements: 'The consumer understands how management interfaces are protected (see Principle 11) and what functionality is available via those interfaces.'
 filters: 'The consumer understands how management interfaces are protected (see Principle 11) and what functionality is available via those interfaces.'
 hint: 'Do you tell consumers what functionality and protection is available for management interfaces?'
-dependsOnLots: 'PaaS, IaaS'
+depends:
+  -
+    on: lot
+    being:
+      - PaaS
+      - IaaS
 assuranceApproach: 2answers-type2
 type: boolean
 filterLabel: 'Management interface protection'

--- a/g6/minimumContractPeriod.yml
+++ b/g6/minimumContractPeriod.yml
@@ -1,4 +1,11 @@
-dependsOnLots: 'SaaS, PaaS, IaaS, SCS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+      - SCS
 type: radios
 options:
     -

--- a/g6/networksConnected.yml
+++ b/g6/networksConnected.yml
@@ -1,4 +1,10 @@
-dependsOnLots: 'SaaS, PaaS, IaaS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
 mockAnswer: Internet
 hint: 'Choose all that apply.'
 type: checkboxes

--- a/g6/offlineWorking.yml
+++ b/g6/offlineWorking.yml
@@ -1,4 +1,10 @@
-dependsOnLots: 'SaaS, PaaS, IaaS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
 type: boolean
 filterLabel: 'Offline working and syncing supported'
 validations:

--- a/g6/onboardingGuidance.yml
+++ b/g6/onboardingGuidance.yml
@@ -1,7 +1,12 @@
 requirements: 'The consumer understands how to safely connect to the service whilst minimising risk to the consumer’s systems.'
 filters: 'The consumer understands how to safely connect to the service whilst minimising risk to the consumer’s systems.'
 hint: 'Do you provide onboarding guidance covering secure connection to the service?'
-dependsOnLots: 'PaaS, IaaS'
+depends:
+  -
+    on: lot
+    being:
+      - PaaS
+      - IaaS
 assuranceApproach: 2answers-type1
 type: boolean
 filterLabel: 'Onboarding guidance provided'

--- a/g6/openSource.yml
+++ b/g6/openSource.yml
@@ -1,4 +1,10 @@
-dependsOnLots: 'SaaS, PaaS, IaaS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
 type: boolean
 filterLabel: 'Open-source software used and supported'
 validations:

--- a/g6/openStandardsSupported.yml
+++ b/g6/openStandardsSupported.yml
@@ -1,4 +1,10 @@
-dependsOnLots: 'SaaS, PaaS, IaaS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
 hint: 'Take a look at the GOV.UK Open Standards principles for more information on open standards.'
 type: boolean
 filterLabel: 'Open standards supported and documented'

--- a/g6/otherConsumers.yml
+++ b/g6/otherConsumers.yml
@@ -1,7 +1,13 @@
 requirements: 'Consumers should understand the types of consumer they share the service or platform with.'
 filters: 'Consumers should understand the types of consumer they share the service or platform with.'
 hint: 'What types of other consumer do you share the service or platform with?'
-dependsOnLots: 'SaaS, PaaS, IaaS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
 assuranceApproach: 3answers-type1
 type: radios
 options:

--- a/g6/persistentStorage.yml
+++ b/g6/persistentStorage.yml
@@ -1,4 +1,10 @@
-dependsOnLots: 'SaaS, PaaS, IaaS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
 type: boolean
 filterLabel: 'Persistent storage supported'
 validations:

--- a/g6/personnelSecurityChecks.yml
+++ b/g6/personnelSecurityChecks.yml
@@ -1,7 +1,13 @@
 requirements: 'Consumers should be content with the level of security screening conducted on service provider staff with access to their information or with ability to affect their service.'
 filters: 'Consumers should be content with the level of security screening conducted on service provider staff with access to their information or with ability to affect their service.'
 hint: 'What kind of personnel security do you apply to staff who have access to the service? Choose all that apply.'
-dependsOnLots: 'SaaS, PaaS, IaaS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
 assuranceApproach: 2answers-type1
 type: checkboxes
 options:

--- a/g6/priceString.yml
+++ b/g6/priceString.yml
@@ -1,5 +1,12 @@
 hint: 'This is an indicative price. Users will be able to refer to your pricing document for more information.'
-dependsOnLots: 'SaaS, PaaS, IaaS, SCS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+      - SCS
 validations:
   -
     name: no_min_price_specified

--- a/g6/pricingDocumentURL.yml
+++ b/g6/pricingDocumentURL.yml
@@ -1,5 +1,12 @@
 question: 'Pricing document'
-dependsOnLots: 'SaaS, PaaS, IaaS, SCS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+      - SCS
 mockAnswer: 'Pricing Document Umbraco 102014.odf'
 hint: 'Please upload your pricing document. This document will not be indexed by search on the Digital Marketplace. Use an Open Document Format (ODF) or PDF/A (eg .pdf, .odt). (Maximum file size 5MB.)'
 type: upload

--- a/g6/provisioningTime.yml
+++ b/g6/provisioningTime.yml
@@ -1,4 +1,10 @@
-dependsOnLots: 'SaaS, PaaS, IaaS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
 hint: 'How long does it take to get your service up and running? For example 1 to 5 hours, 2 to 3 days.'
 type: text
 validations:

--- a/g6/restrictAdministratorPermissions.yml
+++ b/g6/restrictAdministratorPermissions.yml
@@ -1,7 +1,13 @@
 requirements: 'The consumer can manage the risks of their own privileged access, e.g. through ‘principle of least privilege’, providing the ability to constrain permissions given to consumer administrators.'
 filters: 'The consumer can manage the risks of their own privileged access, e.g. through ‘principle of least privilege’, providing the ability to constrain permissions given to consumer administrators.'
 hint: 'Can consumers restrict permissions given to their administrators?'
-dependsOnLots: 'SaaS, PaaS, IaaS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
 assuranceApproach: 2answers-type2
 type: boolean
 filterLabel: 'Administrator permissions'

--- a/g6/secureConfigurationManagement.yml
+++ b/g6/secureConfigurationManagement.yml
@@ -1,7 +1,13 @@
 requirements: 'Consumers should be sufficiently confident that configuration management processes are in place to ensure the integrity of the solution through development, testing and deployment.'
 filters: 'Consumers should be sufficiently confident that configuration management processes are in place to ensure the integrity of the solution through development, testing and deployment.'
 hint: 'Do you have configuration management in place to ensure the integrity of the service through development, testing and deployment?'
-dependsOnLots: 'SaaS, PaaS, IaaS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
 assuranceApproach: 2answers-type1
 type: boolean
 filterLabel: 'Software configuration management'

--- a/g6/secureDesign.yml
+++ b/g6/secureDesign.yml
@@ -1,7 +1,13 @@
 requirements: 'Consumers should be sufficiently confident that development is carried out in line with industry good practice regarding secure design, coding, testing and deployment.'
 filters: 'Consumers should be sufficiently confident that development is carried out in line with industry good practice regarding secure design, coding, testing and deployment.'
 hint: 'Is development carried out in line with industry good practice regarding secure design, coding, testing and deployment?'
-dependsOnLots: 'SaaS, PaaS, IaaS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
 assuranceApproach: 2answers-type1
 type: boolean
 filterLabel: 'Secure design, coding, testing and deployment'

--- a/g6/secureDevelopment.yml
+++ b/g6/secureDevelopment.yml
@@ -1,7 +1,13 @@
 requirements: 'Consumers should be sufficiently confident that new and evolving threats are reviewed and the service improved in line with them.'
 filters: 'Consumers should be sufficiently confident that new and evolving threats are reviewed and the service improved in line with them.'
 hint: 'Are new and evolving threats reviewed and your services improved accordingly?'
-dependsOnLots: 'SaaS, PaaS, IaaS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
 assuranceApproach: 2answers-type1
 type: boolean
 filterLabel: 'Secure development'

--- a/g6/selfServiceProvisioning.yml
+++ b/g6/selfServiceProvisioning.yml
@@ -1,4 +1,10 @@
-dependsOnLots: 'SaaS, PaaS, IaaS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
 type: boolean
 filterLabel: 'Self-service provisioning supported'
 validations:

--- a/g6/serviceAvailabilityPercentage.yml
+++ b/g6/serviceAvailabilityPercentage.yml
@@ -1,7 +1,13 @@
 requirements: 'Consumers should be sufficiently confident that the availability commitments of the service, including their ability to recover from outages, meets their business needs.'
 filters: 'Consumers should be sufficiently confident that the availability commitments of the service, including their ability to recover from outages, meets their business needs.'
 hint: 'What is the availability of the service? eg 99.99'
-dependsOnLots: 'SaaS, PaaS, IaaS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
 assuranceApproach: 3answers-type1
 type: percentage
 filterLabel: 'Service availability'

--- a/g6/serviceBenefits.yml
+++ b/g6/serviceBenefits.yml
@@ -1,6 +1,13 @@
 hint: 'Include benefits that show how your service helps users improve their business. Use active phrases, eg publish content from multiple devices, quickly manage content on the move.  (Maximum 10 words per benefit. Maximum 10 benefits.)'
 mockAnswer: 'Publish content, Quickly manage content on the move'
-dependsOnLots: 'SaaS, PaaS, IaaS, SCS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+      - SCS
 listItemName: 'service benefit'
 type: list
 addthing: 'Add another business benefit'

--- a/g6/serviceConfigurationGuidance.yml
+++ b/g6/serviceConfigurationGuidance.yml
@@ -1,7 +1,12 @@
 requirements: 'The consumer understands the security requirements on their processes, uses, and infrastructure related to the use of the service.'
 filters: 'The consumer understands the security requirements on their processes, uses, and infrastructure related to the use of the service.'
 hint: 'Do you provide guidance on service configuration options and the relative impacts on security?'
-dependsOnLots: 'PaaS, IaaS'
+depends:
+  -
+    on: lot
+    being:
+      - PaaS
+      - IaaS
 assuranceApproach: 3answers-type2
 type: boolean
 filterLabel: 'Service configuration guidance'

--- a/g6/serviceDefinitionDocumentURL.yml
+++ b/g6/serviceDefinitionDocumentURL.yml
@@ -1,7 +1,14 @@
 question: 'Service definition document'
 hint: 'Please upload your service definition. Refer to the ITT documentation for further guidance on what to include. This document will not be indexed by search on the Digital Marketplace. Use an Open Document Format (ODF) or PDF/A (eg .pdf, .odt). (Maximum file size 5MB.)'
 mockAnswer: 'Umbraco Service_Definition 102014.odf'
-dependsOnLots: 'SaaS, PaaS, IaaS, SCS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+      - SCS
 type: upload
 validations:
   -

--- a/g6/serviceFeatures.yml
+++ b/g6/serviceFeatures.yml
@@ -1,6 +1,13 @@
 hint: 'Include the technical features of your product, eg graphical workflow, remote access. (Maximum 10 words per feature. Maximum 10 features.)'
 mockAnswer: 'Graphical workflow, Remote access, Revision control'
-dependsOnLots: 'SaaS, PaaS, IaaS, SCS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+      - SCS
 listItemName: 'service feature'
 type: list
 addthing: 'Add another feature'

--- a/g6/serviceManagementModel.yml
+++ b/g6/serviceManagementModel.yml
@@ -1,7 +1,13 @@
 requirements: 'Consumers have sufficient confidence that the technical approach the service provider uses to manage the service does not put their data or service at risk.'
 filters: 'Consumers have sufficient confidence that the technical approach the service provider uses to manage the service does not put their data or service at risk.'
 hint: 'Which technical approach do you use for your service management? Choose 1.'
-dependsOnLots: 'SaaS, PaaS, IaaS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
 assuranceApproach: 2answers-type1
 type: radios
 options:

--- a/g6/serviceName.yml
+++ b/g6/serviceName.yml
@@ -1,6 +1,13 @@
 hint: 'Include your product name only. Using additional keywords may impact your acceptance on to the Digital Marketplace.'
 mockAnswer: 'Umbraco CMS'
-dependsOnLots: 'SaaS, PaaS, IaaS, SCS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+      - SCS
 type: text
 validations:
   -

--- a/g6/serviceOffboarding.yml
+++ b/g6/serviceOffboarding.yml
@@ -1,4 +1,10 @@
-dependsOnLots: 'SaaS, PaaS, IaaS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
 type: boolean
 filterLabel: 'Service offboarding process included'
 validations:

--- a/g6/serviceOnboarding.yml
+++ b/g6/serviceOnboarding.yml
@@ -1,4 +1,10 @@
-dependsOnLots: 'SaaS, PaaS, IaaS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
 type: boolean
 filterLabel: 'Service onboarding process included'
 validations:

--- a/g6/serviceSummary.yml
+++ b/g6/serviceSummary.yml
@@ -1,6 +1,13 @@
 hint: 'Please provide a short description of your service. (Maximum 50 words.) You''ll be asked to go into more detail about the features and benefits of your service on the next page. Company information should not be included here. You can provide a company description for your supplier page elsewhere.'
 mockAnswer: 'Professional website development to enhance the delivery and performance of online services based on Sitecore or Umbraco Content Management Systems. We provide development and support services for large scale, business critical websites for many organisations including NHS Direct, Department for Education and the Department for Business, Innovation and Skills.'
-dependsOnLots: 'SaaS, PaaS, IaaS, SCS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+      - SCS
 type: textarea
 maxLengthInWords: 50
 validations:

--- a/g6/serviceTypesIaaS.yml
+++ b/g6/serviceTypesIaaS.yml
@@ -1,4 +1,7 @@
-dependsOnLots: IaaS
+depends:
+  -
+    on: lot
+    being: IaaS
 hint: 'You can choose multiple categories.'
 mockAnswer: Compute
 type: checkboxes

--- a/g6/serviceTypesSCS.yml
+++ b/g6/serviceTypesSCS.yml
@@ -1,4 +1,7 @@
-dependsOnLots: SCS
+depends:
+  -
+    on: lot
+    being: SCS
 hint: 'You can choose multiple categories'
 mockAnswer: 'Content management system'
 type: checkboxes

--- a/g6/serviceTypesSaaS.yml
+++ b/g6/serviceTypesSaaS.yml
@@ -1,4 +1,7 @@
-dependsOnLots: SaaS
+depends:
+  -
+    on: lot
+    being: SaaS
 hint: 'You can choose multiple categories'
 mockAnswer: Content management system
 type: checkboxes

--- a/g6/servicesManagementSepartion.yml
+++ b/g6/servicesManagementSepartion.yml
@@ -1,7 +1,13 @@
 requirements: 'Consumers should have confidence that their management of the service is kept separate from other consumers (covered separately as part of Principle 9).'
 filters: 'Consumers should have confidence that their management of the service is kept separate from other consumers (covered separately as part of Principle 9).'
 hint: 'Is your management of a consumer’s service kept separate from other consumers?'
-dependsOnLots: 'SaaS, PaaS, IaaS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
 assuranceApproach: 4answers-type3
 type: boolean
 filterLabel: 'Services management separation'

--- a/g6/servicesSeparation.yml
+++ b/g6/servicesSeparation.yml
@@ -1,7 +1,13 @@
 requirements: 'Consumers should have confidence that the service provides sufficient separation of their data and service from other consumers of the service.'
 filters: 'Consumers should have confidence that the service provides sufficient separation of their data and service from other consumers of the service.'
 hint: 'Do you securely separate consumer data and services from other consumers of the service?'
-dependsOnLots: 'SaaS, PaaS, IaaS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
 assuranceApproach: 4answers-type3
 type: boolean
 filterLabel: 'Services separation'

--- a/g6/sfiaRateDocumentURL.yml
+++ b/g6/sfiaRateDocumentURL.yml
@@ -1,5 +1,12 @@
 question: 'Skills Framework for the Information Age (SFIA) rate card'
-dependsOnLots: 'SaaS, PaaS, IaaS, SCS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+      - SCS
 mockAnswer: 'Rate Card Umbraco 102014.odf'
 hint: 'Please upload your SFIA rate card if you have one. This document will not be indexed by search on the Digital Marketplace. Use an Open Document Format (ODF) or PDF/A (eg .pdf, .odt). (Maximum file size 5MB.)'
 type: upload

--- a/g6/supportAvailability.yml
+++ b/g6/supportAvailability.yml
@@ -1,4 +1,11 @@
-dependsOnLots: 'SaaS, PaaS, IaaS, SCS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+      - SCS
 hint: 'eg 24/7 or 9 to 5. (Maximum 20 words.)'
 type: text
 validations:

--- a/g6/supportForThirdParties.yml
+++ b/g6/supportForThirdParties.yml
@@ -1,4 +1,11 @@
-dependsOnLots: 'SaaS, PaaS, IaaS, SCS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+      - SCS
 type: boolean
 filterLabel: 'Support accessible to any third-party suppliers'
 validations:

--- a/g6/supportResponseTime.yml
+++ b/g6/supportResponseTime.yml
@@ -1,4 +1,11 @@
-dependsOnLots: 'SaaS, PaaS, IaaS, SCS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+      - SCS
 hint: 'How long will it take until support can begin to be provided? eg 1 hour or 1 business day. (Maximum 20 words.)'
 type: text
 validations:

--- a/g6/supportTypes.yml
+++ b/g6/supportTypes.yml
@@ -1,4 +1,11 @@
-dependsOnLots: 'SaaS, PaaS, IaaS, SCS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+      - SCS
 hint: 'Choose all that apply.'
 type: checkboxes
 options:

--- a/g6/supportedBrowsers.yml
+++ b/g6/supportedBrowsers.yml
@@ -1,4 +1,10 @@
-dependsOnLots: 'SaaS, PaaS, IaaS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
 hint: 'Choose all that apply.'
 type: checkboxes
 options:

--- a/g6/supportedDevices.yml
+++ b/g6/supportedDevices.yml
@@ -1,4 +1,10 @@
-dependsOnLots: 'SaaS, PaaS, IaaS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
 hint: 'Choose all that apply.'
 type: checkboxes
 options:

--- a/g6/terminationCost.yml
+++ b/g6/terminationCost.yml
@@ -1,4 +1,7 @@
-dependsOnLots: 'PaaS, IaaS, SCS'
+depends:
+  -
+    on: lot
+    being: 'PaaS, IaaS, SCS'
 type: boolean
 filterLabel: 'Termination cost'
 validations:

--- a/g6/termsAndConditionsDocumentURL.yml
+++ b/g6/termsAndConditionsDocumentURL.yml
@@ -1,6 +1,13 @@
 question: 'Please upload your terms and conditions document'
 mockAnswer: 'Umbraco Terms_Conditions 102014.odf'
-dependsOnLots: 'SaaS, PaaS, IaaS, SCS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+      - SCS
 hint: 'Please upload your terms and conditions document. This document will not be indexed by search on the Digital Marketplace. Use an Open Document Format (ODF) or PDF/A (eg .pdf, .odt). (Maximum file size 5MB.)'
 type: upload
 validations:

--- a/g6/thirdPartyComplianceMonitoring.yml
+++ b/g6/thirdPartyComplianceMonitoring.yml
@@ -1,7 +1,13 @@
 requirements: 'The consumer understands and accepts how the service provider manages the conformance of their suppliers with security requirements.'
 filters: 'The consumer understands and accepts how the service provider manages the conformance of their suppliers with security requirements.'
 hint: 'Do you manage your third-party suppliers'' compliance with relevant security requirements?'
-dependsOnLots: 'SaaS, PaaS, IaaS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
 assuranceApproach: 2answers-type1
 type: boolean
 filterLabel: 'Third-party supplier compliance monitoring'

--- a/g6/thirdPartyDataSharingInformation.yml
+++ b/g6/thirdPartyDataSharingInformation.yml
@@ -1,7 +1,13 @@
 requirements: 'The consumer understands and accepts how their information is shared with, or accessible by, third party suppliers and their supply chains.'
 filters: 'The consumer understands and accepts how their information is shared with, or accessible by, third party suppliers and their supply chains.'
 hint: 'Do you inform consumers how much of their information is shared with, or accessible by, third-party suppliers and their supply chains?'
-dependsOnLots: 'SaaS, PaaS, IaaS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
 assuranceApproach: 2answers-type1
 type: boolean
 filterLabel: 'Visibility of data shared with third-party suppliers'

--- a/g6/thirdPartyRiskAssessment.yml
+++ b/g6/thirdPartyRiskAssessment.yml
@@ -1,7 +1,13 @@
 requirements: 'The consumer understands and accepts how the service provider manages security risks from third party suppliers and delivery partners.'
 filters: 'The consumer understands and accepts how the service provider manages security risks from third party suppliers and delivery partners.'
 hint: 'Do you manage the risks to your service from third-party suppliers and delivery partners?'
-dependsOnLots: 'SaaS, PaaS, IaaS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
 assuranceApproach: 2answers-type1
 type: boolean
 filterLabel: 'Third-party supplier risk assessment'

--- a/g6/thirdPartySecurityRequirements.yml
+++ b/g6/thirdPartySecurityRequirements.yml
@@ -1,7 +1,13 @@
 requirements: 'The consumer understands and accepts how the service provider’s procurement processes place security requirements on third party suppliers and delivery partners.'
 filters: 'The consumer understands and accepts how the service provider’s procurement processes place security requirements on third party suppliers and delivery partners.'
 hint: 'Do you ensure that relevant security requirements, such as the Cloud Security Principles, are placed on third-party suppliers and delivery partners?'
-dependsOnLots: 'SaaS, PaaS, IaaS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
 assuranceApproach: 2answers-type1
 type: boolean
 filterLabel: 'Third-party supplier security requirements'

--- a/g6/trainingProvided.yml
+++ b/g6/trainingProvided.yml
@@ -1,7 +1,13 @@
 requirements: 'The consumer can educate those administrating and using the service in how to use it safely and securely.'
 filters: 'The consumer can educate those administrating and using the service in how to use it safely and securely.'
 hint: 'Do you provide user or administrator training on the use of the service and its security?'
-dependsOnLots: 'SaaS, PaaS, IaaS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
 assuranceApproach: 2answers-type1
 type: boolean
 filterLabel: Training

--- a/g6/trialOption.yml
+++ b/g6/trialOption.yml
@@ -1,4 +1,10 @@
-dependsOnLots: 'SaaS, PaaS, IaaS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
 type: boolean
 filterLabel: 'Trial option'
 validations:

--- a/g6/undefined.yml
+++ b/g6/undefined.yml
@@ -1,5 +1,8 @@
 id: serviceTypes
-dependsOnLots: SaaS
+depends:
+  -
+    on: lot
+    being: SaaS
 hint: 'You can choose multiple categories'
 mockAnswer: 'Content management system'
 type: checkboxes

--- a/g6/userAccessControlManagement.yml
+++ b/g6/userAccessControlManagement.yml
@@ -1,7 +1,13 @@
 requirements: 'The consumer has sufficient confidence that other consumers cannot access, modify or otherwise affect their service management.'
 filters: 'The consumer has sufficient confidence that other consumers cannot access, modify or otherwise affect their service management.'
 hint: 'Can consumers manage only their own service, and not access, modify or otherwise affect the service of other consumers via management tools and interfaces?'
-dependsOnLots: 'SaaS, PaaS, IaaS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
 assuranceApproach: 2answers-type2
 type: boolean
 filterLabel: 'User access control within management interfaces'

--- a/g6/userAuthenticateManagement.yml
+++ b/g6/userAuthenticateManagement.yml
@@ -1,7 +1,13 @@
 requirements: 'The consumer has sufficient confidence that only authorised individuals from the consumer organisation are able to authenticate to and access management interfaces for the service (Principle 10 should be used assess the risks of different approaches to meet this objective).'
 filters: 'The consumer has sufficient confidence that only authorised individuals from the consumer organisation are able to authenticate to and access management interfaces for the service (Principle 10 should be used assess the risks of different approaches to meet this objective).'
 hint: 'Can only authorised individuals from the consumer organisation access management interfaces for the service?'
-dependsOnLots: 'SaaS, PaaS, IaaS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
 assuranceApproach: 2answers-type2
 type: boolean
 filterLabel: 'User authentication and access management'

--- a/g6/userAuthenticateSupport.yml
+++ b/g6/userAuthenticateSupport.yml
@@ -1,7 +1,13 @@
 requirements: 'The consumer has sufficient confidence that only authorised individuals from the consumer organisation are able to perform actions affecting the consumer’s service through support channels.'
 filters: 'The consumer has sufficient confidence that only authorised individuals from the consumer organisation are able to perform actions affecting the consumer’s service through support channels.'
 hint: 'Can only authorised individuals from the consumer organisation perform actions affecting the consumer’s service through your support channels?'
-dependsOnLots: 'SaaS, PaaS, IaaS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
 assuranceApproach: 2answers-type2
 type: boolean
 filterLabel: 'User access control through support channels'

--- a/g6/vatIncluded.yml
+++ b/g6/vatIncluded.yml
@@ -1,4 +1,11 @@
-dependsOnLots: 'SaaS, PaaS, IaaS, SCS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+      - SCS
 type: boolean
 filterLabel: 'VAT included'
 validations:

--- a/g6/vendorCertifications.yml
+++ b/g6/vendorCertifications.yml
@@ -1,4 +1,11 @@
-dependsOnLots: 'SaaS, PaaS, IaaS, SCS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+      - SCS
 hint: 'Examples of certifications include VMware Certified Professional and Oracle Gold Partner. (Optional.)'
 listItemName: 'certification example'
 type: list

--- a/g6/vulnerabilityAssessment.yml
+++ b/g6/vulnerabilityAssessment.yml
@@ -1,7 +1,13 @@
 requirements: 'Consumers should have confidence that potential new threats, vulnerabilities or exploitation techniques which could affect the service are assessed and corrective action is taken.'
 filters: 'Consumers should have confidence that potential new threats, vulnerabilities or exploitation techniques which could affect the service are assessed and corrective action is taken.'
 hint: 'Are potential threats, vulnerabilities or exploitation techniques which could affect the service assessed, and are corrective actions taken?'
-dependsOnLots: 'SaaS, PaaS, IaaS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
 assuranceApproach: 2answers-type1
 type: boolean
 filterLabel: 'Vulnerability assessment'

--- a/g6/vulnerabilityMitigationPrioritisation.yml
+++ b/g6/vulnerabilityMitigationPrioritisation.yml
@@ -1,7 +1,13 @@
 requirements: 'Consumers should have confidence that the severity of threats and vulnerabilities are considered within the context of the service and this information is used to prioritise implementation of mitigations.'
 filters: 'Consumers should have confidence that the severity of threats and vulnerabilities are considered within the context of the service and this information is used to prioritise implementation of mitigations.'
 hint: 'Is the severity of threats and vulnerabilities considered and do you use this information to prioritise implementation of mitigations?'
-dependsOnLots: 'SaaS, PaaS, IaaS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
 assuranceApproach: 2answers-type1
 type: boolean
 filterLabel: 'Vulnerability mitigation prioritisation'

--- a/g6/vulnerabilityMonitoring.yml
+++ b/g6/vulnerabilityMonitoring.yml
@@ -1,7 +1,13 @@
 requirements: 'Consumers should have confidence that relevant sources of information relating to threat, vulnerability and exploitation technique information are monitored by the service provider.'
 filters: 'Consumers should have confidence that relevant sources of information relating to threat, vulnerability and exploitation technique information are monitored by the service provider.'
 hint: 'Do you monitor relevant sources of information relating to threat, vulnerability and exploitation techniques?'
-dependsOnLots: 'SaaS, PaaS, IaaS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
 assuranceApproach: 2answers-type1
 type: boolean
 filterLabel: 'Vulnerability monitoring'

--- a/g6/vulnerabilityTimescales.yml
+++ b/g6/vulnerabilityTimescales.yml
@@ -1,7 +1,13 @@
 requirements: 'Consumers should have confidence that service provider timescales for implementing mitigations to vulnerabilities found within the service are made available to them.'
 filters: 'Consumers should have confidence that service provider timescales for implementing mitigations to vulnerabilities found within the service are made available to them.'
 hint: 'Do you make timescales available for implementing mitigations to vulnerabilities?'
-dependsOnLots: 'SaaS, PaaS, IaaS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
 assuranceApproach: 2answers-type1
 type: boolean
 filterLabel: 'Vulnerability mitigation timescales'

--- a/g6/vulnerabilityTracking.yml
+++ b/g6/vulnerabilityTracking.yml
@@ -1,7 +1,13 @@
 requirements: 'Consumers should have confidence that known vulnerabilities within the service are tracked until suitable mitigations have been deployed through a suitable change management process.'
 filters: 'Consumers should have confidence that known vulnerabilities within the service are tracked until suitable mitigations have been deployed through a suitable change management process.'
 hint: 'Are known vulnerabilities within the service tracked until suitable mitigations have been deployed?'
-dependsOnLots: 'SaaS, PaaS, IaaS'
+depends:
+  -
+    on: lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
 assuranceApproach: 2answers-type1
 type: boolean
 filterLabel: 'Vulnerability tracking'


### PR DESCRIPTION
This changes the way dependencies between questions are described in the YAML,
to be more generic than just 'lot'.

This is with the aim of having a method on [content loader](https://github.com/alphagov/digitalmarketplace-utils/blob/master/dmutils/content_loader.py)
which would exclude irrelevant questions when provided with a service, rather than having to do this in the views:
```
{% if service_data['lot']|lower in question['depends_on_lots'] %}
```