### PR TITLE
Enforce array type for dependencies

### DIFF
--- a/g6/codeLibraryLanguages.yml
+++ b/g6/codeLibraryLanguages.yml
@@ -1,7 +1,8 @@
 depends:
   -
     "on": lot
-    being: SaaS
+    being:
+      - SaaS
 hint: 'Examples of code libraries include AWS Ruby SDK and Stripe-Java. Examples of languages include PHP and Python. (Maximum 10 languages.) (Optional.) '
 listItemName: 'code libraries example'
 type: list

--- a/g6/identityStandards.yml
+++ b/g6/identityStandards.yml
@@ -1,7 +1,8 @@
 depends:
   -
     "on": lot
-    being: SaaS
+    being:
+      - SaaS
 hint: 'Examples of identity standards include OAuth and SAML. (Optional.)'
 listItemName: 'identity standards example'
 type: list

--- a/g6/serviceTypesIaaS.yml
+++ b/g6/serviceTypesIaaS.yml
@@ -1,7 +1,8 @@
 depends:
   -
     "on": lot
-    being: IaaS
+    being:
+      - IaaS
 hint: 'You can choose multiple categories.'
 type: checkboxes
 options:

--- a/g6/serviceTypesSCS.yml
+++ b/g6/serviceTypesSCS.yml
@@ -1,7 +1,8 @@
 depends:
   -
     "on": lot
-    being: SCS
+    being:
+      - SCS
 hint: 'You can choose multiple categories'
 type: checkboxes
 options:

--- a/g6/serviceTypesSaaS.yml
+++ b/g6/serviceTypesSaaS.yml
@@ -1,7 +1,8 @@
 depends:
   -
     "on": lot
-    being: SaaS
+    being:
+      - SaaS
 hint: 'You can choose multiple categories'
 type: checkboxes
 options:

--- a/g6/terminationCost.yml
+++ b/g6/terminationCost.yml
@@ -1,7 +1,10 @@
 depends:
   -
     "on": lot
-    being: 'PaaS, IaaS, SCS'
+    being:
+      - PaaS
+      - IaaS
+      - SCS
 type: boolean
 filterLabel: 'Termination cost'
 validations:

--- a/tests/schemas/question.json
+++ b/tests/schemas/question.json
@@ -17,18 +17,20 @@
     },
     "options": {
       "type": "array",
-      "properties": {
-        "label": {
-          "type": "string"
-        },
-        "filterLabel": {
-          "type": "string"
-        },
-        "description": {
-          "type": "string"
-        },
-        "value": {
-          "type": "string"
+      "items": {
+        "properties": {
+          "label": {
+            "type": "string"
+          },
+          "filterLabel": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          }
         }
       },
       "additionalProperties": false,
@@ -38,12 +40,14 @@
     },
     "validations": {
       "type": "array",
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "message": {
-          "type": "string"
+      "items": {
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
         }
       },
       "additionalProperties": false,
@@ -54,12 +58,14 @@
     },
     "depends": {
       "type": "array",
-      "properties": {
-        "on": {
-          "type": "string"
-        },
-        "being": {
-          "type": "array"
+      "items": {
+        "properties": {
+          "on": {
+            "type": "string"
+          },
+          "being": {
+            "type": "array"
+          }
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
We should be strict about this because Python, for example, will let you do both of these:
```
for lot in "sass paas iaas" …
for lot in ["sass", "paas", "iaas"] …
```
but the behaviour will be subtly different.

This also fixes a mistake in the schemas which prevented this from being enforced.